### PR TITLE
Use columnSize and decimalDigits (Fixes issue 15)

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
@@ -61,8 +61,8 @@ public class TableSnapshotGenerator extends HibernateSnapshotGenerator {
                 if (!matcher.group(2).isEmpty())
                     dataType.setColumnSize(Integer.parseInt(matcher.group(2)));
             } else {
-                dataType.setDecimalDigits(Integer.parseInt(matcher.group(2)));
-                dataType.setRadix(Integer.parseInt(matcher.group(3)));
+                dataType.setColumnSize(Integer.parseInt(matcher.group(2)));
+                dataType.setDecimalDigits(Integer.parseInt(matcher.group(3)));
             }
 
             dataType.setDataTypeId(hibernateColumn.getSqlTypeCode());


### PR DESCRIPTION
Radix is not used in the DataType-class (toString()).
I'm not quite sure whether the DataType.toString() method is correct
