### PR TITLE
Fixes #39 - NullPointerException when running "mvn liquibase:diff"

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
@@ -79,7 +79,7 @@ public class TableSnapshotGenerator extends HibernateSnapshotGenerator {
                 if (isPrimaryKeyColumn) {
                     if (primaryKey == null) {
                         primaryKey = new PrimaryKey();
-                        primaryKey.setName(table.getPrimaryKey().getName());
+                        primaryKey.setName(hibernatePrimaryKey.getName());
                     }
                     primaryKey.addColumnName(pkColumnPosition++, column.getName());
 


### PR DESCRIPTION
The `Table` instance obviously doesn't have a primary key set yet, since that is what we are trying to do, so set the primary key name from the `hibernatePrimaryKey` instead.
