### PR TITLE
Jpa persistence.xml database

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/JpaPersistenceDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/JpaPersistenceDatabase.java
@@ -1,0 +1,69 @@
+package liquibase.ext.hibernate.database;
+
+import liquibase.database.DatabaseConnection;
+import liquibase.exception.DatabaseException;
+import liquibase.ext.hibernate.database.connection.HibernateConnection;
+import liquibase.ext.hibernate.database.connection.HibernateDriver;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
+import org.hibernate.jpa.boot.spi.Bootstrap;
+import org.hibernate.service.ServiceRegistry;
+import org.springframework.orm.jpa.persistenceunit.DefaultPersistenceUnitManager;
+
+import javax.persistence.spi.PersistenceUnitInfo;
+import java.util.Collections;
+
+/**
+ * Database implementation for JPA configurations.
+ * This supports passing a JPA persistence XML file reference.
+ */
+public class JpaPersistenceDatabase extends HibernateDatabase {
+
+    public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
+        return conn.getURL().startsWith("jpa:persistence:");
+    }
+
+    @Override
+    public String getDefaultDriver(String url) {
+        if (url.startsWith("jpa:persistence:")) {
+            return HibernateDriver.class.getName();
+        }
+        return null;
+    }
+
+    @Override
+    protected Configuration buildConfiguration(HibernateConnection connection) throws DatabaseException {
+        return buildConfigurationFromXml(connection);
+    }
+
+    /**
+     * Build a Configuration object assuming the connection path is a persistence XML configuration file.
+     */
+
+    protected Configuration buildConfigurationFromXml(HibernateConnection connection) {
+        DefaultPersistenceUnitManager internalPersistenceUnitManager = new DefaultPersistenceUnitManager();
+
+        internalPersistenceUnitManager.setPersistenceXmlLocation(connection.getPath());
+        internalPersistenceUnitManager.setDefaultPersistenceUnitRootLocation(null);
+
+        internalPersistenceUnitManager.preparePersistenceUnitInfos();
+        PersistenceUnitInfo persistenceUnitInfo = internalPersistenceUnitManager.obtainDefaultPersistenceUnitInfo();
+
+        EntityManagerFactoryBuilderImpl builder = (EntityManagerFactoryBuilderImpl) Bootstrap.getEntityManagerFactoryBuilder(persistenceUnitInfo,
+                Collections.emptyMap(), null);
+        ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+        return builder.buildHibernateConfiguration(serviceRegistry);
+    }
+
+
+    @Override
+    public String getShortName() {
+        return "jpaPersistence";
+    }
+
+    @Override
+    protected String getDefaultDatabaseProductName() {
+        return "JPA Persistence";
+    }
+
+}

--- a/src/test/java/liquibase/ext/hibernate/database/JPAPersistenceDatabaseTest.java
+++ b/src/test/java/liquibase/ext/hibernate/database/JPAPersistenceDatabaseTest.java
@@ -1,0 +1,28 @@
+package liquibase.ext.hibernate.database;
+
+import liquibase.CatalogAndSchema;
+import liquibase.database.Database;
+import liquibase.integration.commandline.CommandLineUtils;
+import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotControl;
+import liquibase.snapshot.SnapshotGeneratorFactory;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * @author Mårten Svantesson
+ */
+public class JPAPersistenceDatabaseTest {
+    @Test
+    public void persistenceXML() throws Exception {
+        String url = "jpa:persistence:META-INF/persistence.xml";
+        Database database = CommandLineUtils.createDatabaseObject(this.getClass().getClassLoader(), url, null, null, null, null, null, false, false, null, null, null, null, null);
+
+        assertNotNull(database);
+
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
+
+        HibernateEjb3DatabaseTest.assertEjb3HibernateMapped(snapshot);
+    }
+}


### PR DESCRIPTION
A new data base implementation that enables specification of a persistence.xml.
