### PR TITLE
Use the unique constraint name from the Hibernate model for table-bas…

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -39,6 +39,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                 org.hibernate.mapping.UniqueKey hibernateUnique = (org.hibernate.mapping.UniqueKey) uniqueIterator.next();
 
                 UniqueConstraint uniqueConstraint = new UniqueConstraint();
+                uniqueConstraint.setName(hibernateUnique.getName());
                 uniqueConstraint.setTable(table);
                 Iterator columnIterator = hibernateUnique.getColumnIterator();
                 int i = 0;


### PR DESCRIPTION
Attempts to fix #106 by using Hibernate's constraint name for constraints declared using @Table/@UniqueConstraint.