### PR TITLE
Accidentally reverted changes for fixing Issue #27: Hibernate Envers support

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
@@ -13,6 +13,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.envers.configuration.AuditConfiguration;
 
 /**
  * Base class for all Hibernate Databases. This extension interacts with Hibernate by creating standard liquibase.database.Database implementations that
@@ -45,6 +46,7 @@ public abstract class HibernateDatabase extends AbstractJdbcDatabase {
             configureNamingStrategy(this.configuration, ((HibernateConnection) ((JdbcConnection) conn).getUnderlyingConnection()));
 
             this.configuration.buildMappings();
+            AuditConfiguration.getFor (configuration);
             this.dialect = configureDialect();
 
             afterSetup();

--- a/src/test/java/liquibase/ext/hibernate/SpringPackageScanningIntegrationTest.java
+++ b/src/test/java/liquibase/ext/hibernate/SpringPackageScanningIntegrationTest.java
@@ -24,6 +24,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.ejb.Ejb3Configuration;
+import org.hibernate.envers.configuration.AuditConfiguration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.junit.After;
@@ -216,6 +217,7 @@ public class SpringPackageScanningIntegrationTest {
 
         Configuration configuration = configured.getHibernateConfiguration();
         configuration.buildMappings();
+        AuditConfiguration.getFor(configuration);
         return configuration;
     }
 

--- a/src/test/java/liquibase/ext/hibernate/database/HibernateEjb3DatabaseTest.java
+++ b/src/test/java/liquibase/ext/hibernate/database/HibernateEjb3DatabaseTest.java
@@ -40,6 +40,8 @@ public class HibernateEjb3DatabaseTest {
                 hasProperty("name", is("AuctionItem")),
                 hasProperty("name", is("Item")),
                 hasProperty("name", is("AuditedItem")),
+                hasProperty("name", is("AuditedItem_AUD")),
+                hasProperty("name", is("REVINFO")),
                 hasProperty("name", is("WatcherSeqTable"))));
 
 
@@ -95,6 +97,8 @@ public class HibernateEjb3DatabaseTest {
                 hasProperty("name", is("auction_item")),
                 hasProperty("name", is("item")),
                 hasProperty("name", is("audited_item")),
+                hasProperty("name", is("audited_item_aud")),
+                hasProperty("name", is("revinfo")),
                 hasProperty("name", is("WatcherSeqTable"))));
 
     }


### PR DESCRIPTION
Accidentally reverted changes from commit 'Fix for Issue #27: Hibernate4: Envers tables not generated' by  Michał Dettlaff (committed on 21 Jun 2014)

- Since that revert Hibernate Envers is not working in hibernate4.2 branch anymore
- Reactivated Hibernate Envers and adopted unit tests accordingly