### PR TITLE
Disable second level cache since it is not really needed by liquibase (close #130)

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateClassicDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateClassicDatabase.java
@@ -45,7 +45,7 @@ public class HibernateClassicDatabase extends HibernateDatabase {
         config.configure(getHibernateConnection().getPath());
 
         config.setProperty("hibernate.temp.use_jdbc_metadata_defaults", "false");
-
+        config.setProperty("hibernate.cache.use_second_level_cache", "false");
 
         ServiceRegistry standardRegistry = configuration.getStandardServiceRegistryBuilder()
                 .applySettings(config.getProperties())

--- a/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
@@ -86,6 +86,7 @@ public class HibernateSpringPackageDatabase extends JpaPersistenceDatabase {
 
         Map<String, String> map = new HashMap<>();
         map.put(AvailableSettings.DIALECT, getProperty(AvailableSettings.DIALECT));
+        map.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, Boolean.FALSE.toString());
         EntityManagerFactoryBuilderImpl builder = (EntityManagerFactoryBuilderImpl) Bootstrap.getEntityManagerFactoryBuilder(persistenceUnitInfo, map);
         return builder.build();
 

--- a/src/test/java/com/example/ejb3/auction/Bid.java
+++ b/src/test/java/com/example/ejb3/auction/Bid.java
@@ -1,11 +1,22 @@
 package com.example.ejb3.auction;
 
-import javax.persistence.*;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Transient;
 
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorValue("Y")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class Bid extends Persistent {
     private AuctionItem item;
     private float amount;

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -13,6 +13,7 @@
     <class>com.example.ejb3.auction.Item</class>
     <class>com.example.ejb3.auction.AuditedItem</class>
     <properties>
+      <property name="hibernate.cache.use_second_level_cache" value="false"/>
       <property name="hibernate.archive.autodetection" value="false"/>
       <property name="javax.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
       <property name="javax.persistence.jdbc.user" value="sa"/>


### PR DESCRIPTION
Second level cache makes liquibase fail with hibernate 5. Since it's not really needed by liquibase and possibly harmful for some type of second level caches, the easiest is to disable it.

*Note:* I've disabled it for some subclasses of `HibernateDatabase`. This is enough for me but you might want to add the same parameter to some others.