### PR TITLE
Fixes #179 - upgrade liquibase to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>3.5.3</version>
+			<version>3.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
 
     @SuppressWarnings("unchecked")
-	public IndexSnapshotGenerator() {
+    public IndexSnapshotGenerator() {
         super(Index.class, new Class[]{Table.class, ForeignKey.class, UniqueConstraint.class});
     }
 

--- a/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
@@ -10,7 +10,8 @@ import java.util.Iterator;
 
 public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
 
-    public IndexSnapshotGenerator() {
+    @SuppressWarnings("unchecked")
+	public IndexSnapshotGenerator() {
         super(Index.class, new Class[]{Table.class, ForeignKey.class, UniqueConstraint.class});
     }
 
@@ -19,20 +20,20 @@ public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
         if (example.getSnapshotId() != null) {
             return example;
         }
-        Table table = ((Index) example).getTable();
+        Relation table = ((Index) example).getTable();
         org.hibernate.mapping.Table hibernateTable = findHibernateTable(table, snapshot);
         if (hibernateTable == null) {
             return example;
         }
-        Iterator indexIterator = hibernateTable.getIndexIterator();
+        Iterator<org.hibernate.mapping.Index> indexIterator = hibernateTable.getIndexIterator();
         while (indexIterator.hasNext()) {
-            org.hibernate.mapping.Index hibernateIndex = (org.hibernate.mapping.Index) indexIterator.next();
+            org.hibernate.mapping.Index hibernateIndex = indexIterator.next();
             Index index = new Index();
             index.setTable(table);
             index.setName(hibernateIndex.getName());
-            Iterator columnIterator = hibernateIndex.getColumnIterator();
+            Iterator<org.hibernate.mapping.Column> columnIterator = hibernateIndex.getColumnIterator();
             while (columnIterator.hasNext()) {
-                org.hibernate.mapping.Column hibernateColumn = (org.hibernate.mapping.Column) columnIterator.next();
+                org.hibernate.mapping.Column hibernateColumn = columnIterator.next();
                 index.getColumns().add(new Column(hibernateColumn.getName()).setRelation(table));
             }
 
@@ -57,15 +58,15 @@ public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
             if (hibernateTable == null) {
                 return;
             }
-            Iterator indexIterator = hibernateTable.getIndexIterator();
+            Iterator<org.hibernate.mapping.Index> indexIterator = hibernateTable.getIndexIterator();
             while (indexIterator.hasNext()) {
-                org.hibernate.mapping.Index hibernateIndex = (org.hibernate.mapping.Index) indexIterator.next();
+                org.hibernate.mapping.Index hibernateIndex =  indexIterator.next();
                 Index index = new Index();
                 index.setTable(table);
                 index.setName(hibernateIndex.getName());
-                Iterator columnIterator = hibernateIndex.getColumnIterator();
+                Iterator<org.hibernate.mapping.Column> columnIterator = hibernateIndex.getColumnIterator();
                 while (columnIterator.hasNext()) {
-                    org.hibernate.mapping.Column hibernateColumn = (org.hibernate.mapping.Column) columnIterator.next();
+                    org.hibernate.mapping.Column hibernateColumn = columnIterator.next();
                     index.getColumns().add(new Column(hibernateColumn.getName()).setRelation(table));
                 }
                 LOG.info("Found index " + index.getName());


### PR DESCRIPTION
See: https://github.com/liquibase/liquibase-hibernate/issues/179

Fixed the one compile error that came of the upgrade.

Also made some minor changes to get rid of warnings about generics.