### PR TITLE
Set UniqueConstraint.clustered to false 

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -45,6 +45,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                 UniqueConstraint uniqueConstraint = new UniqueConstraint();
                 uniqueConstraint.setName(hibernateUnique.getName());
                 uniqueConstraint.setTable(table);
+                uniqueConstraint.setClustered(false); // No way to set true via Hibernate
                 Iterator columnIterator = hibernateUnique.getColumnIterator();
                 int i = 0;
                 while (columnIterator.hasNext()) {
@@ -65,6 +66,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                 if (column.isUnique()) {
                     UniqueConstraint uniqueConstraint = new UniqueConstraint();
                     uniqueConstraint.setTable(table);
+                    uniqueConstraint.setClustered(false); // No way to set true via Hibernate
                     String name = "UC_" + table.getName().toUpperCase() + column.getName().toUpperCase() + "_COL";
                     if (name.length() > 64) {
                         name = name.substring(0, 63);


### PR DESCRIPTION
In Issue #191, neivkovic reported unnecessery recreation of unique constraints.  I believe this is due the liqubase-core setting the UniqueConstraint.clustered to true/false. Currently the liquibase-hibernate snapshot does not set UniqueConstraint.clustered at all resulting in a true/false != null, thus it appears the unqiue constraint has changed (See screenshot below).

I only did some light research on whether hibernate can support setting the cluster attribute on a unique constraint, but from what I say this is not possible so I think it is safe to set to false. There could be potential fallout if liquibase-core does not always set the UniqueConstraint.clustered to true/false. I am comparing against Postgresl, which does not support the attribute so I am pretty sure it will set it for other dbs as well.

<img width="1260" alt="LiquibaseHibernate-Issue#191" src="https://user-images.githubusercontent.com/4026643/58750806-a0bf5300-8464-11e9-898b-6624e19d21e0.png">
