### PR TITLE
Fix for #136: Excessive and invalid re-creation of foreign key, index and unique constraints, plus postgres sequences (hibernate4)

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedIndexChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedIndexChangeGenerator.java
@@ -34,7 +34,7 @@ public class ChangedIndexChangeGenerator extends
             Difference unique = differences.getDifference("unique");
             if ( unique != null && isNullOrFalse( unique.getReferenceValue() ) && isNullOrFalse( unique.getComparedValue() ) )
             {
-                differences.removeDifference(UNIQUE);;
+                differences.removeDifference("unique");
                 if (!differences.hasDifferences()) {
                     return null;
                 }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedIndexChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedIndexChangeGenerator.java
@@ -31,13 +31,19 @@ public class ChangedIndexChangeGenerator extends
                                DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase,
                                ChangeGeneratorChain chain) {
         if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
-            Difference difference = differences.getDifference("unique");
-            if (difference != null) {
-                if (difference.getReferenceValue() == null && (Boolean)difference.getComparedValue() == false) {
+            Difference unique = differences.getDifference("unique");
+            if ( unique != null && isNullOrFalse( unique.getReferenceValue() ) && isNullOrFalse( unique.getComparedValue() ) )
+            {
+                differences.removeDifference(UNIQUE);;
+                if (!differences.hasDifferences()) {
                     return null;
                 }
             }
         }
         return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+    }
+        
+    private boolean isNullOrFalse( Object value ) {
+        return value == null || !(Boolean)value;
     }
 }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
@@ -40,8 +40,10 @@ public class ChangedUniqueConstraintChangeGenerator implements ChangedObjectChan
     public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
             Difference difference = differences.getDifference("unique");
-            if (difference != null) {
-                if (difference.getReferenceValue() == null && (Boolean)(difference.getComparedValue()) == true) {
+            if ( unique != null && isNullOrFalse( unique.getReferenceValue() ) && isNullOrFalse( unique.getComparedValue() ) )
+            {
+                differences.removeDifference("unique");
+                if (!differences.hasDifferences()) {
                     return null;
                 }
             }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
@@ -60,4 +60,8 @@ public class ChangedUniqueConstraintChangeGenerator implements ChangedObjectChan
     public Change[] fixOutputAsSchema(Change[] changes, CompareControl.SchemaComparison[] schemaComparisons) {
         return changes;
     }
+    
+    private boolean isNullOrFalse( Object value ) {
+        return value == null || !(Boolean)value;
+    }
 }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
@@ -39,7 +39,7 @@ public class ChangedUniqueConstraintChangeGenerator implements ChangedObjectChan
     @Override
     public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
-            Difference difference = differences.getDifference("unique");
+            Difference unique = differences.getDifference("unique");
             if ( unique != null && isNullOrFalse( unique.getReferenceValue() ) && isNullOrFalse( unique.getComparedValue() ) )
             {
                 differences.removeDifference("unique");


### PR DESCRIPTION
For details see issue: #136 

Credits for the code: https://github.com/liquibase/liquibase-hibernate/issues/136#issuecomment-262974124