### PR TITLE
Revert "Bump hamcrest-library from 1.3 to 2.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>2.2</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Reverts liquibase/liquibase-hibernate#235

Breaking tests.