### PR TITLE
Fix index matching error

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
@@ -86,7 +86,13 @@ public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
             org.hibernate.mapping.Column col = hibernateIndex.getColumnIterator().next();
             return col.isUnique();
         } else {
-            return null;
+            /*
+            It seems that because Hibernate does not implement the unique property of the Jpa composite index,
+            the diff command appears 'diffence', because the unique property of the entity index is 'null',
+            and the value read from the database is 'false', resulting in the generated changeSet after the Drop and
+            Recreate Index.
+            */
+            return false;
         }
     }
 }


### PR DESCRIPTION
I use Liquibase 3.8 and postgresql10.
I found a bug of IndexSnapshotGenerator.
It seems that the problem is caused by the difference in the processing of the unique properties of hibernate and jpa.
Finally, there is no unique attribute in the attributes of Index in snapshot, and there is a unique attribute in the attributes scanned from the database.In the end, it will be judged that the inconsistency causes the same changelog to be generated after each diff command is about the same index of drop and create