### PR TITLE
When set the default schema/catalog name is used instead of the default HIBERNATE one

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
@@ -328,12 +328,18 @@ public abstract class HibernateDatabase extends AbstractJdbcDatabase {
 
     @Override
     public String getDefaultSchemaName() {
-        return DEFAULT_SCHEMA;
+        if(defaultSchemaName == null) {
+            return DEFAULT_SCHEMA;
+        }
+        return defaultSchemaName;
     }
 
     @Override
     public String getDefaultCatalogName() {
-        return DEFAULT_SCHEMA;
+        if(defaultCatalogName == null) {
+            return DEFAULT_SCHEMA;
+        }
+        return defaultCatalogName;
     }
 
     @Override


### PR DESCRIPTION
Hi,

  i ran into the problem when i set the following options in my pom.xml

`
<referenceDefaultSchemaName>main</referenceDefaultSchemaName>              <diffIncludeSchema>true</diffIncludeSchema>
`

i always got **HIBERNATE.** in front of my changes  but i expect it to be **main.**

This fixes it for me.