### PR TITLE
Updated liquibase-core version to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>3.2.0</version>
+			<version>3.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hsqldb</groupId>
@@ -171,8 +171,8 @@
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.8</source>
+						<target>1.8</target>
 						<optimize>true</optimize>
 						<debug>true</debug>
 						<encoding>${project.build.sourceEncoding}</encoding>
@@ -180,6 +180,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
 					<configuration>
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 						<reportFormat>plain</reportFormat>

--- a/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
@@ -3,12 +3,8 @@ package liquibase.ext.hibernate.snapshot;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
-import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
-import liquibase.structure.core.ForeignKey;
-import liquibase.structure.core.Index;
-import liquibase.structure.core.Table;
-import liquibase.structure.core.UniqueConstraint;
+import liquibase.structure.core.*;
 
 import java.util.Iterator;
 
@@ -43,12 +39,11 @@ public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
                 Iterator columnIterator = hibernateIndex.getColumnIterator();
                 while (columnIterator.hasNext()) {
                     org.hibernate.mapping.Column hibernateColumn = (org.hibernate.mapping.Column) columnIterator.next();
-                    index.getColumns().add(hibernateColumn.getName());
+                    index.getColumns().add(new Column(hibernateColumn.getName()));
                 }
                 LOG.info("Found index " + index.getName());
                 table.getIndexes().add(index);
             }
         }
     }
-
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/PrimaryKeySnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/PrimaryKeySnapshotGenerator.java
@@ -44,12 +44,11 @@ public class PrimaryKeySnapshotGenerator extends HibernateSnapshotGenerator {
                 Index index = new Index();
                 index.setName("IX_" + pk.getName());
                 index.setTable(table);
-                index.setColumns(pk.getColumnNames());
+                index.setColumns(pk.getColumns());
                 index.setUnique(true);
                 pk.setBackingIndex(index);
                 table.getIndexes().add(index);
             }
         }
     }
-
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
@@ -95,7 +95,7 @@ public class TableSnapshotGenerator extends HibernateSnapshotGenerator {
                         primaryKey = new PrimaryKey();
                         primaryKey.setName(hibernatePrimaryKey.getName());
                     }
-                    primaryKey.addColumnName(pkColumnPosition++, column.getName());
+                    primaryKey.addColumn(pkColumnPosition++, column);
 
                     String identifierGeneratorStrategy = hibernateColumn.getValue().isSimpleValue() ?
                             ((SimpleValue) hibernateColumn.getValue()).getIdentifierGeneratorStrategy() : null;

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -4,6 +4,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.UniqueConstraint;
 
@@ -44,7 +45,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                 while (columnIterator.hasNext()) {
                     org.hibernate.mapping.Column hibernateColumn = (org.hibernate.mapping.Column) columnIterator.next();
                     name += "_" + hibernateColumn.getName().toUpperCase();
-                    uniqueConstraint.addColumn(i, hibernateColumn.getName());
+                    uniqueConstraint.addColumn(i, new Column(hibernateColumn.getName()));
                     i++;
                 }
                 uniqueConstraint.setName(name);
@@ -58,7 +59,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                     UniqueConstraint uniqueConstraint = new UniqueConstraint();
                     uniqueConstraint.setTable(table);
                     String name = "UC_" + table.getName().toUpperCase() + column.getName().toUpperCase() + "_COL";
-                    uniqueConstraint.addColumn(0, column.getName());
+                    uniqueConstraint.addColumn(0, new Column(column.getName()));
                     uniqueConstraint.setName(name);
                     LOG.info("Found unique constraint " + uniqueConstraint.toString());
                     table.getUniqueConstraints().add(uniqueConstraint);

--- a/src/main/java/liquibase/ext/hibernate/snapshot/extension/TableGeneratorSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/extension/TableGeneratorSnapshotGenerator.java
@@ -28,7 +28,7 @@ public class TableGeneratorSnapshotGenerator implements ExtendedSnapshotGenerato
 
         PrimaryKey primaryKey = new PrimaryKey();
         primaryKey.setName(tableGenerator.getTableName() + "PK");
-        primaryKey.addColumnName(0, pkColumn.getName());
+        primaryKey.addColumn(0, pkColumn);
         primaryKey.setTable(table);
         table.setPrimaryKey(primaryKey);
 


### PR DESCRIPTION
In accordance with requirements of https://github.com/liquibase/liquibase-hibernate/issues/80
Updated liquibase-core version to 3.3.1
Also updated dependencies blocking compilation and testing.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-858) by [Unito](https://www.unito.io/learn-more)
