### PR TITLE
Feature/nationalized characters

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
@@ -284,6 +284,8 @@ public abstract class HibernateDatabase extends AbstractJdbcDatabase {
         configureNewIdentifierGeneratorSupport(getProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS), metadataBuilder);
         configureImplicitNamingStrategy(getProperty(AvailableSettings.IMPLICIT_NAMING_STRATEGY), metadataBuilder);
         configurePhysicalNamingStrategy(getProperty(AvailableSettings.PHYSICAL_NAMING_STRATEGY), metadataBuilder);
+        metadataBuilder.enableGlobalNationalizedCharacterDataSupport(
+                Boolean.parseBoolean(getProperty(AvailableSettings.USE_NATIONALIZED_CHARACTER_DATA)));
     }
 
     /**

--- a/src/main/java/liquibase/ext/hibernate/database/HibernateEjb3Database.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateEjb3Database.java
@@ -49,7 +49,7 @@ public class HibernateEjb3Database extends HibernateDatabase {
     }
 
     /**
-     * Calls {@link #createEntityManagerFactory()} to create and save the entity manager factory.
+     * Calls {@link #createEntityManagerFactoryBuilder()} to create and save the entity manager factory.
      */
     @Override
     protected Metadata buildMetadataFromPath() throws DatabaseException {
@@ -81,6 +81,7 @@ public class HibernateEjb3Database extends HibernateDatabase {
 
         Map<String, Object> properties = new HashMap<>();
         properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, Boolean.FALSE.toString());
+        properties.put(AvailableSettings.USE_NATIONALIZED_CHARACTER_DATA, getProperty(AvailableSettings.USE_NATIONALIZED_CHARACTER_DATA));
 
         final EntityManagerFactoryBuilderImpl builder = (EntityManagerFactoryBuilderImpl) persistenceProvider.getEntityManagerFactoryBuilderOrNull(getHibernateConnection().getPath(), properties, null);
         return builder;

--- a/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
@@ -98,7 +98,8 @@ public class HibernateSpringPackageDatabase extends JpaPersistenceDatabase {
         map.put(AvailableSettings.SCANNER_DISCOVERY, "");	// disable scanning of all classes and hbm.xml files. Only scan speficied packages
         map.put(EnversSettings.AUDIT_TABLE_PREFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_PREFIX,""));
         map.put(EnversSettings.AUDIT_TABLE_SUFFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_SUFFIX,"_AUD"));
-        
+        map.put(AvailableSettings.USE_NATIONALIZED_CHARACTER_DATA, getProperty(AvailableSettings.USE_NATIONALIZED_CHARACTER_DATA));
+
         EntityManagerFactoryBuilderImpl builder = (EntityManagerFactoryBuilderImpl) Bootstrap.getEntityManagerFactoryBuilder(persistenceUnitInfo, map);
         
         return builder;

--- a/src/test/java/liquibase/ext/hibernate/HibernateIntegrationTest.java
+++ b/src/test/java/liquibase/ext/hibernate/HibernateIntegrationTest.java
@@ -277,13 +277,13 @@ public class HibernateIntegrationTest {
         Set<Index> unexpectedIndexes = diffResult.getUnexpectedObjects(Index.class);
         for (Iterator<Index> iterator = unexpectedIndexes.iterator(); iterator.hasNext(); ) {
             Index index = iterator.next();
-            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getTable().getName()) || "DATABASECHANGELOG".equalsIgnoreCase(index.getTable().getName()))
+            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getRelation().getName()) || "DATABASECHANGELOG".equalsIgnoreCase(index.getRelation().getName()))
                 diffResult.getUnexpectedObjects().remove(index);
         }
         Set<Index> missingIndexes = diffResult.getMissingObjects(Index.class);
         for (Iterator<Index> iterator = missingIndexes.iterator(); iterator.hasNext(); ) {
             Index index = iterator.next();
-            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getTable().getName()) || "DATABASECHANGELOG".equalsIgnoreCase(index.getTable().getName()))
+            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getRelation().getName()) || "DATABASECHANGELOG".equalsIgnoreCase(index.getRelation().getName()))
                 diffResult.getMissingObjects().remove(index);
         }
         Set<PrimaryKey> unexpectedPrimaryKeys = diffResult.getUnexpectedObjects(PrimaryKey.class);

--- a/src/test/java/liquibase/ext/hibernate/SpringPackageScanningIntegrationTest.java
+++ b/src/test/java/liquibase/ext/hibernate/SpringPackageScanningIntegrationTest.java
@@ -341,15 +341,15 @@ public class SpringPackageScanningIntegrationTest {
         Set<Index> unexpectedIndexes = diffResult.getUnexpectedObjects(Index.class);
         for (Iterator<Index> iterator = unexpectedIndexes.iterator(); iterator.hasNext(); ) {
             Index index = iterator.next();
-            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getTable().getName())
-                    || "DATABASECHANGELOG".equalsIgnoreCase(index.getTable().getName()))
+            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getRelation().getName())
+                    || "DATABASECHANGELOG".equalsIgnoreCase(index.getRelation().getName()))
                 diffResult.getUnexpectedObjects().remove(index);
         }
         Set<Index> missingIndexes = diffResult.getMissingObjects(Index.class);
         for (Iterator<Index> iterator = missingIndexes.iterator(); iterator.hasNext(); ) {
             Index index = iterator.next();
-            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getTable().getName())
-                    || "DATABASECHANGELOG".equalsIgnoreCase(index.getTable().getName()))
+            if ("DATABASECHANGELOGLOCK".equalsIgnoreCase(index.getRelation().getName())
+                    || "DATABASECHANGELOG".equalsIgnoreCase(index.getRelation().getName()))
                 diffResult.getMissingObjects().remove(index);
         }
         Set<PrimaryKey> unexpectedPrimaryKeys = diffResult.getUnexpectedObjects(PrimaryKey.class);

--- a/src/test/java/liquibase/ext/hibernate/database/HibernateClassicDatabaseTest.java
+++ b/src/test/java/liquibase/ext/hibernate/database/HibernateClassicDatabaseTest.java
@@ -4,6 +4,7 @@ import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.integration.commandline.CommandLineUtils;
+import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
@@ -13,9 +14,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.*;
+
 
 public class HibernateClassicDatabaseTest {
 
@@ -64,13 +67,27 @@ public class HibernateClassicDatabaseTest {
     @Test
     public void simpleHibernateUrl() throws Exception {
         String url = "hibernate:classic:com/example/pojo/Hibernate.cfg.xml";
-        Database database = CommandLineUtils.createDatabaseObject(this.getClass().getClassLoader(), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
 
         assertNotNull(database);
 
         DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
 
         assertPojoHibernateMapped(snapshot);
+    }
+
+    @Test
+    public void nationalizedCharactersHibernateUrl() throws Exception {
+        String url = "hibernate:classic:com/example/pojo/Hibernate.cfg.xml?hibernate.use_nationalized_character_data=true";
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+
+        assertNotNull(database);
+
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
+
+        assertPojoHibernateMapped(snapshot);
+        Table watcherTable = (Table) snapshot.get(new Table().setName("watcher").setSchema(new Schema()));
+        assertEquals("nvarchar", watcherTable.getColumn("name").getType().getTypeName());
     }
 
     public static void assertPojoHibernateMapped(DatabaseSnapshot snapshot) {

--- a/src/test/java/liquibase/ext/hibernate/database/HibernateEjb3DatabaseTest.java
+++ b/src/test/java/liquibase/ext/hibernate/database/HibernateEjb3DatabaseTest.java
@@ -3,6 +3,7 @@ package liquibase.ext.hibernate.database;
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.integration.commandline.CommandLineUtils;
+import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
@@ -10,6 +11,7 @@ import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.*;
@@ -19,13 +21,27 @@ public class HibernateEjb3DatabaseTest {
     @Test
     public void simpleEjb3Url() throws Exception {
         String url = "hibernate:ejb3:auction";
-        Database database = CommandLineUtils.createDatabaseObject(this.getClass().getClassLoader(), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
 
         assertNotNull(database);
 
         DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
 
         assertEjb3HibernateMapped(snapshot);
+    }
+
+    @Test
+    public void nationalizedCharactersEjb3Url() throws Exception {
+        String url = "hibernate:ejb3:auction?hibernate.use_nationalized_character_data=true";
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+
+        assertNotNull(database);
+
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
+
+        assertEjb3HibernateMapped(snapshot);
+        Table userTable = (Table) snapshot.get(new Table().setName("user").setSchema(new Schema()));
+        assertEquals("nvarchar", userTable.getColumn("userName").getType().getTypeName());
     }
 
     public static void assertEjb3HibernateMapped(DatabaseSnapshot snapshot) {

--- a/src/test/java/liquibase/ext/hibernate/database/HibernateSpringDatabaseTest.java
+++ b/src/test/java/liquibase/ext/hibernate/database/HibernateSpringDatabaseTest.java
@@ -11,6 +11,8 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Table;
 import org.hibernate.dialect.H2Dialect;
 import org.junit.After;
 import org.junit.Test;
@@ -56,7 +58,7 @@ public class HibernateSpringDatabaseTest {
     @Test
     public void simpleSpringUrl() throws Exception {
         String url = "hibernate:spring:spring.ctx.xml?bean=sessionFactory";
-        Database database = CommandLineUtils.createDatabaseObject(this.getClass().getClassLoader(), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
 
         assertNotNull(database);
 
@@ -66,15 +68,43 @@ public class HibernateSpringDatabaseTest {
     }
 
     @Test
+    public void nationalizedCharactersSpringBeanUrl() throws Exception {
+        String url = "hibernate:spring:spring.ctx.xml?hibernate.use_nationalized_character_data=true&bean=sessionFactory";
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+
+        assertNotNull(database);
+
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
+
+        HibernateClassicDatabaseTest.assertPojoHibernateMapped(snapshot);
+        Table watcherTable = (Table) snapshot.get(new Table().setName("watcher").setSchema(new Schema()));
+        assertEquals("nvarchar", watcherTable.getColumn("name").getType().getTypeName());
+    }
+
+    @Test
     public void simpleSpringScanningUrl() throws Exception {
         String url = "hibernate:spring:com.example.ejb3.auction?dialect=" + H2Dialect.class.getName();
-        Database database = CommandLineUtils.createDatabaseObject(this.getClass().getClassLoader(), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
 
         assertNotNull(database);
 
         DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
 
         HibernateEjb3DatabaseTest.assertEjb3HibernateMapped(snapshot);
+    }
+
+    @Test
+    public void nationalizedCharactersSpringScanningUrl() throws Exception {
+        String url = "hibernate:spring:com.example.ejb3.auction?hibernate.use_nationalized_character_data=true&dialect=" + H2Dialect.class.getName();
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+
+        assertNotNull(database);
+
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
+
+        HibernateEjb3DatabaseTest.assertEjb3HibernateMapped(snapshot);
+        Table userTable = (Table) snapshot.get(new Table().setName("user").setSchema(new Schema()));
+        assertEquals("nvarchar", userTable.getColumn("userName").getType().getTypeName());
     }
 
 }

--- a/src/test/java/liquibase/ext/hibernate/database/JPAPersistenceDatabaseTest.java
+++ b/src/test/java/liquibase/ext/hibernate/database/JPAPersistenceDatabaseTest.java
@@ -3,6 +3,7 @@ package liquibase.ext.hibernate.database;
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.integration.commandline.CommandLineUtils;
+import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
@@ -17,7 +18,7 @@ public class JPAPersistenceDatabaseTest {
     @Test
     public void persistenceXML() throws Exception {
         String url = "jpa:persistence:META-INF/persistence.xml";
-        Database database = CommandLineUtils.createDatabaseObject(this.getClass().getClassLoader(), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), url, null, null, null, null, null, false, false, null, null, null, null, null, null, null);
 
         assertNotNull(database);
 


### PR DESCRIPTION
Implemented as suggested in #268, and added relevant tests. Also cleaned up some deprecated method calls in the test classes.

Note that for xml-based mappings (as seen in the classic + spring bean cases), the `hibernate.use_nationalized_character_data` isn't respected -- that looks like a hibernate-core issue, as referenced here: https://hibernate.atlassian.net/browse/HHH-9673

But, anything using the `EntityManager` / ejb3 base should be good.

I do have a question for the maintainers, though -- is there any explicit design reason to **not** support arbitrary hibernate config properties? Or is the code just not currently set up for that?



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-917) by [Unito](https://www.unito.io)
