### PR TITLE
avoid excessive re-generation of sequences on diffChangeLog

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
@@ -1,0 +1,53 @@
+package liquibase.ext.hibernate.diff;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.Difference;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
+
+/**
+ * startValue and incrementBy values are retrieved by {@link liquibase.ext.hibernate.snapshot.SequenceSnapshotGenerator},
+ * but it may not be the case for {@link liquibase.snapshot.jvm.SequenceSnapshotGenerator}, so we should drop
+ * differences where compared value is null.
+ */
+public class ChangedSequenceChangeGenerator extends liquibase.diff.output.changelog.core.ChangedSequenceChangeGenerator {
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (Sequence.class.isAssignableFrom(objectType)) {
+            return PRIORITY_ADDITIONAL;
+        }
+        return PRIORITY_NONE;
+    }
+
+    /**
+     * Remove a difference if one of it's value is null.
+     *
+     * @param differences
+     * @param difference
+     * @return
+     */
+    private boolean removeIfNull(ObjectDifferences differences, Difference difference) {
+        if (difference.getComparedValue() == null || difference.getReferenceValue() == null) {
+            return differences.removeDifference(difference.getField());
+        }
+        return false;
+    }
+
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            for (Difference difference : differences.getDifferences()) {
+                removeIfNull(differences, difference);
+            }
+        }
+
+        return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+    }
+}

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -2,3 +2,4 @@ liquibase.ext.hibernate.diff.ChangedColumnChangeGenerator
 liquibase.ext.hibernate.diff.ChangedForeignKeyChangeGenerator
 liquibase.ext.hibernate.diff.MissingSequenceChangeGenerator
 liquibase.ext.hibernate.diff.UnexpectedIndexChangeGenerator
+liquibase.ext.hibernate.diff.ChangedSequenceChangeGenerator


### PR DESCRIPTION
Close #205

Problem is that since #155 (which was a good idea), some users get their sequences generated again and again when running `diffChangeLog` command.

`liquibase-core` is not always capable of retrieving `incrementBy` and `startValue` sequence metadata, according to implementation of [this method](https://github.com/liquibase/liquibase/blob/6986dffb9f67c613db89f2aee72ad82a71a68d26/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java#L146-L277), some database can only return the sequence name, while `incrementBy` and `startValue` are not retrieved.

If those case, the SequenceChangeGenerator generates a change, as incrementBy is "1" instead of "null".

This PR removes `incrementBy` and `startValue` differences when the comparison database is not supposed to provide those values, so it doesn't generates sequences that should not change.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1136) by [Unito](https://www.unito.io)
