### PR TITLE
add support org.hibernate.envers.audit_table_prefix and org.hibernate…

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
@@ -8,6 +8,7 @@ import javax.persistence.spi.PersistenceUnitInfo;
 
 import liquibase.Scope;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.envers.configuration.EnversSettings;
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.springframework.core.io.ClassPathResource;
@@ -95,6 +96,8 @@ public class HibernateSpringPackageDatabase extends JpaPersistenceDatabase {
         map.put(AvailableSettings.PHYSICAL_NAMING_STRATEGY, getHibernateConnection().getProperties().getProperty(AvailableSettings.PHYSICAL_NAMING_STRATEGY));
         map.put(AvailableSettings.IMPLICIT_NAMING_STRATEGY, getHibernateConnection().getProperties().getProperty(AvailableSettings.IMPLICIT_NAMING_STRATEGY));
         map.put(AvailableSettings.SCANNER_DISCOVERY, "");	// disable scanning of all classes and hbm.xml files. Only scan speficied packages
+        map.put(EnversSettings.AUDIT_TABLE_PREFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_PREFIX,""));
+        map.put(EnversSettings.AUDIT_TABLE_SUFFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_SUFFIX,"_AUD"));
         
         EntityManagerFactoryBuilderImpl builder = (EntityManagerFactoryBuilderImpl) Bootstrap.getEntityManagerFactoryBuilder(persistenceUnitInfo, map);
         

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
@@ -1,0 +1,53 @@
+package liquibase.ext.hibernate.diff;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.Difference;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
+
+/**
+ * startValue and incrementBy values are retrieved by {@link liquibase.ext.hibernate.snapshot.SequenceSnapshotGenerator},
+ * but it may not be the case for {@link liquibase.snapshot.jvm.SequenceSnapshotGenerator}, so we should drop
+ * differences where compared value is null.
+ */
+public class ChangedSequenceChangeGenerator extends liquibase.diff.output.changelog.core.ChangedSequenceChangeGenerator {
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (Sequence.class.isAssignableFrom(objectType)) {
+            return PRIORITY_ADDITIONAL;
+        }
+        return PRIORITY_NONE;
+    }
+
+    /**
+     * Remove a difference if one of it's value is null.
+     *
+     * @param differences
+     * @param difference
+     * @return
+     */
+    private boolean removeIfNull(ObjectDifferences differences, Difference difference) {
+        if (difference.getComparedValue() == null || difference.getReferenceValue() == null) {
+            return differences.removeDifference(difference.getField());
+        }
+        return false;
+    }
+
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            for (Difference difference : differences.getDifferences()) {
+                removeIfNull(differences, difference);
+            }
+        }
+
+        return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+    }
+}

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -2,3 +2,4 @@ liquibase.ext.hibernate.diff.ChangedColumnChangeGenerator
 liquibase.ext.hibernate.diff.ChangedForeignKeyChangeGenerator
 liquibase.ext.hibernate.diff.MissingSequenceChangeGenerator
 liquibase.ext.hibernate.diff.UnexpectedIndexChangeGenerator
+liquibase.ext.hibernate.diff.ChangedSequenceChangeGenerator


### PR DESCRIPTION
….envers.audit_table_supfix in referenceUrl
currently Envers always generate table with suffix _AUD (default) event if specify other.
This commit add support Envers table prefix ,suffix in referenceUrl  e.g  `...&org.hibernate.envers.audit_table_prefix=zz_`



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1137) by [Unito](https://www.unito.io/learn-more)
