### PR TITLE
add support org.hibernate.envers.audit_table_prefix and org.hibernate.envers.audit_table_supfix in referenceUrl

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
@@ -8,6 +8,7 @@ import javax.persistence.spi.PersistenceUnitInfo;
 
 import liquibase.Scope;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.envers.configuration.EnversSettings;
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.springframework.core.io.ClassPathResource;
@@ -95,6 +96,8 @@ public class HibernateSpringPackageDatabase extends JpaPersistenceDatabase {
         map.put(AvailableSettings.PHYSICAL_NAMING_STRATEGY, getHibernateConnection().getProperties().getProperty(AvailableSettings.PHYSICAL_NAMING_STRATEGY));
         map.put(AvailableSettings.IMPLICIT_NAMING_STRATEGY, getHibernateConnection().getProperties().getProperty(AvailableSettings.IMPLICIT_NAMING_STRATEGY));
         map.put(AvailableSettings.SCANNER_DISCOVERY, "");	// disable scanning of all classes and hbm.xml files. Only scan speficied packages
+        map.put(EnversSettings.AUDIT_TABLE_PREFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_PREFIX,""));
+        map.put(EnversSettings.AUDIT_TABLE_SUFFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_SUFFIX,"_AUD"));
         
         EntityManagerFactoryBuilderImpl builder = (EntityManagerFactoryBuilderImpl) Bootstrap.getEntityManagerFactoryBuilder(persistenceUnitInfo, map);
         


### PR DESCRIPTION
When working with Envers,  liquibase:diff always use default table prefix-suffix  from hibernate and no way to config it. So I add support for table prefix and table suffix configuration.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1145) by [Unito](https://www.unito.io)
