### PR TITLE
Fix detection of false-positives for sequences and improve SequenceSnapshotGenerator implementation

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
@@ -1,0 +1,59 @@
+package liquibase.ext.hibernate.diff;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.Difference;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Hibernate manages sequences only by the name, startValue and incrementBy fields.
+ * However, non-hibernate databases might return default values for other fields triggering false positives.
+ */
+public class ChangedSequenceChangeGenerator extends liquibase.diff.output.changelog.core.ChangedSequenceChangeGenerator {
+
+    private static final Set<String> HIBERNATE_SEQUENCE_FIELDS;
+
+    static {
+        HashSet<String> hibernateSequenceFields = new HashSet<>();
+        hibernateSequenceFields.add("name");
+        hibernateSequenceFields.add("startValue");
+        hibernateSequenceFields.add("incrementBy");
+        HIBERNATE_SEQUENCE_FIELDS = Collections.unmodifiableSet(hibernateSequenceFields);
+    }
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (Sequence.class.isAssignableFrom(objectType)) {
+            return PRIORITY_ADDITIONAL;
+        }
+        return PRIORITY_NONE;
+    }
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control,
+            Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        if (!(referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase)) {
+            return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+        }
+
+        // if any of the databases is a hibernate database, remove all differences that affect a field not managed by hibernate
+        Set<String> ignoredDifferenceFields = differences.getDifferences().stream()
+                .map(Difference::getField)
+                .filter(differenceField ->  !HIBERNATE_SEQUENCE_FIELDS.contains(differenceField))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        ignoredDifferenceFields.forEach(differences::removeDifference);
+        return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+    }
+
+}

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -1,4 +1,5 @@
 liquibase.ext.hibernate.diff.ChangedColumnChangeGenerator
 liquibase.ext.hibernate.diff.ChangedForeignKeyChangeGenerator
+liquibase.ext.hibernate.diff.ChangedSequenceChangeGenerator
 liquibase.ext.hibernate.diff.MissingSequenceChangeGenerator
 liquibase.ext.hibernate.diff.UnexpectedIndexChangeGenerator


### PR DESCRIPTION
This PR removes the detection of false-positives for sequences when diffing a hibernate-snapshot with any other snapshot.

Hibernate manages sequences only by the `name`, `startValue` and `incrementBy` properties.
However, non-hibernate databases might return default values for other sequence-properties triggering false positives.
By removing all differences that affect a field not managed by Hibernate, false-positives are prevented.

I also cleaned up the implementation of `SequenceSnapshotGenerator`.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2018) by [Unito](https://www.unito.io)
