### PR TITLE
Do not expose the H2 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.1.214</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
The H2 DB is used for testing. Therefore it should be marked as test-only.