### PR TITLE
Fix snyk warning

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,5 @@ ignore:
   SNYK-JAVA-ORGLIQUIBASE-2419059:
     - '*':
         reason: ignore liquibase version
-        expires: 2023-03-07T00:00:00.000Z
         created: 2022-03-07T15:57:03.089Z
 patch: {}


### PR DESCRIPTION
Ignore warning for liquibase version as we use our 0-SNAPSHOT schema