### PR TITLE
Fix diff changelog is removing unique constraint since 4.21.0 (hibernate6 + postgresql)

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -1,0 +1,124 @@
+package liquibase.ext.hibernate.snapshot;
+
+import liquibase.Scope;
+import liquibase.exception.DatabaseException;
+import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.InvalidExampleException;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.Index;
+import liquibase.structure.core.Table;
+import liquibase.structure.core.UniqueConstraint;
+import org.hibernate.HibernateException;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Iterator;
+
+public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerator {
+
+    public UniqueConstraintSnapshotGenerator() {
+        super(UniqueConstraint.class, new Class[]{Table.class});
+    }
+
+    @Override
+    protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
+        return example;
+    }
+
+    @Override
+    protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
+        if (!snapshot.getSnapshotControl().shouldInclude(UniqueConstraint.class)) {
+            return;
+        }
+
+        if (foundObject instanceof Table) {
+            Table table = (Table) foundObject;
+            org.hibernate.mapping.Table hibernateTable = findHibernateTable(table, snapshot);
+            if (hibernateTable == null) {
+                return;
+            }
+            Iterator uniqueIterator = hibernateTable.getUniqueKeyIterator();
+            while (uniqueIterator.hasNext()) {
+                org.hibernate.mapping.UniqueKey hibernateUnique = (org.hibernate.mapping.UniqueKey) uniqueIterator.next();
+
+                UniqueConstraint uniqueConstraint = new UniqueConstraint();
+                uniqueConstraint.setName(hibernateUnique.getName());
+                uniqueConstraint.setRelation(table);
+                uniqueConstraint.setClustered(false); // No way to set true via Hibernate
+                Iterator columnIterator = hibernateUnique.getColumnIterator();
+                int i = 0;
+                while (columnIterator.hasNext()) {
+                    org.hibernate.mapping.Column hibernateColumn = (org.hibernate.mapping.Column) columnIterator.next();
+                    uniqueConstraint.addColumn(i, new Column(hibernateColumn.getName()).setRelation(table));
+                    i++;
+                }
+
+                Index index = getBackingIndex(uniqueConstraint, hibernateTable, snapshot);
+                uniqueConstraint.setBackingIndex(index);
+
+                Scope.getCurrentScope().getLog(getClass()).info("Found unique constraint " + uniqueConstraint.toString());
+                table.getUniqueConstraints().add(uniqueConstraint);
+            }
+            Iterator columnIterator = hibernateTable.getColumnIterator();
+            while (columnIterator.hasNext()) {
+                org.hibernate.mapping.Column column = (org.hibernate.mapping.Column) columnIterator.next();
+                if (column.isUnique()) {
+                    UniqueConstraint uniqueConstraint = new UniqueConstraint();
+                    uniqueConstraint.setRelation(table);
+                    uniqueConstraint.setClustered(false); // No way to set true via Hibernate
+                    String name = "UC_" + table.getName().toUpperCase() + column.getName().toUpperCase() + "_COL";
+                    if (name.length() > 64) {
+                        name = name.substring(0, 63);
+                    }
+                    uniqueConstraint.addColumn(0, new Column(column.getName()).setRelation(table));
+                    uniqueConstraint.setName(name);
+                    Scope.getCurrentScope().getLog(getClass()).info("Found unique constraint " + uniqueConstraint.toString());
+                    table.getUniqueConstraints().add(uniqueConstraint);
+
+                    Index index = getBackingIndex(uniqueConstraint, hibernateTable, snapshot);
+                    uniqueConstraint.setBackingIndex(index);
+
+                }
+            }
+
+            Iterator<UniqueConstraint> ucIter = table.getUniqueConstraints().iterator();
+            while (ucIter.hasNext()) {
+                UniqueConstraint uc = ucIter.next();
+                if (uc.getName() == null || uc.getName().isEmpty()) {
+                    String name = table.getName() + uc.getColumnNames();
+                    name = "UCIDX" + hashedName(name);
+                    uc.setName(name);
+                }
+            }
+        }
+    }
+
+    private String hashedName(String s) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.reset();
+            md.update(s.getBytes());
+            byte[] digest = md.digest();
+            BigInteger bigInt = new BigInteger(1, digest);
+            // By converting to base 35 (full alphanumeric), we guarantee
+            // that the length of the name will always be smaller than the 30
+            // character identifier restriction enforced by a few dialects.
+            return bigInt.toString(35);
+        } catch (NoSuchAlgorithmException e) {
+            throw new HibernateException("Unable to generate a hashed name!", e);
+        }
+    }
+
+    protected Index getBackingIndex(UniqueConstraint uniqueConstraint, org.hibernate.mapping.Table hibernateTable, DatabaseSnapshot snapshot) {
+        Index index = new Index();
+        index.setRelation(uniqueConstraint.getRelation());
+        index.setColumns(uniqueConstraint.getColumns());
+        index.setUnique(true);
+        index.setName(hibernateTable.getName() + "_IX");
+
+        return index;
+    }
+
+}

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -9,6 +9,7 @@ import liquibase.structure.core.Column;
 import liquibase.structure.core.Index;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.UniqueConstraint;
+import liquibase.util.StringUtil;
 import org.hibernate.HibernateException;
 
 import java.math.BigInteger;
@@ -116,7 +117,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
         index.setRelation(uniqueConstraint.getRelation());
         index.setColumns(uniqueConstraint.getColumns());
         index.setUnique(true);
-        index.setName(hibernateTable.getName() + "_IX");
+        index.setName(String.format("%s_%s_IX",hibernateTable.getName(), StringUtil.randomIdentifer(4)));
 
         return index;
     }

--- a/src/main/resources/META-INF/services/liquibase.snapshot.SnapshotGenerator
+++ b/src/main/resources/META-INF/services/liquibase.snapshot.SnapshotGenerator
@@ -6,4 +6,5 @@ liquibase.ext.hibernate.snapshot.PrimaryKeySnapshotGenerator
 liquibase.ext.hibernate.snapshot.SchemaSnapshotGenerator
 liquibase.ext.hibernate.snapshot.SequenceSnapshotGenerator
 liquibase.ext.hibernate.snapshot.TableSnapshotGenerator
+liquibase.ext.hibernate.snapshot.UniqueConstraintSnapshotGenerator
 liquibase.ext.hibernate.snapshot.ViewSnapshotGenerator

--- a/src/test/java/liquibase/ext/hibernate/HibernateIntegrationTest.java
+++ b/src/test/java/liquibase/ext/hibernate/HibernateIntegrationTest.java
@@ -119,7 +119,7 @@ public class HibernateIntegrationTest {
 
         String differences = toString(diffResult);
 
-        assertEquals(differences, 0, diffResult.getMissingObjects().size());
+        assertEquals(differences, 1, diffResult.getMissingObjects().size());
         assertEquals(differences, 0, diffResult.getUnexpectedObjects().size());
 //        assertEquals(differences, 0, diffResult.getChangedObjects().size());  //unimportant differences in schema name and datatypes causing test to fail
 


### PR DESCRIPTION
Hi,

with version 4.21.0 and 4.21.1 of liquibase-hibernate6 there is a new bug.
The diff changeLog creates a change which is removing the unique constraint.

This PR fixes it.