### PR TITLE
chore(workflows): update liquibase build-logic workflows to version v…

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -1,7 +1,6 @@
 name: Attach Artifact to Release
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -9,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.3.4
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.3.3
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.3.4
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.3.3
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.3.4
     secrets: inherit

--- a/.github/workflows/snyk-nightly.yml
+++ b/.github/workflows/snyk-nightly.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   security-scan:
-    uses: liquibase/build-logic/.github/workflows/synk-nightly.yml@v0.3.3
+    uses: liquibase/build-logic/.github/workflows/synk-nightly.yml@v0.3.4
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     # This extension can not execute hibernete tests on Java 8/11. This needs to be fixed and then uncomment the following 2 lines and remove the build and unit-test logic from here
-    #uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.3.3
+    #uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.3.4
     #secrets: inherit
     name: Build & Package
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-hibernate6</artifactId>
-    <version>4.23.1</version>
+    <version>4.23.1-SNAPSHOT</version>
 
     <name>Liquibase Hibernate Integration</name>
     <description>Liquibase extension for hibernate integration including generating changesets based on changed
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:https://github.com/liquibase/liquibase-hibernate.git</connection>
         <url>https://github.com/liquibase/liquibase-hibernate</url>
-        <tag>liquibase-hibernate6-4.23.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
…0.3.4

The liquibase build-logic workflows have been updated to version v0.3.4. This update includes the following changes:

- In the attach-artifact-release.yml workflow, the version has been updated from v0.3.3 to v0.3.4.
- In the create-release.yml workflow, the version has been updated from v0.3.3 to v0.3.4.
- In the release-published.yml workflow, the version has been updated from v0.3.3 to v0.3.4.
- In the snyk-nightly.yml workflow, the version has been updated from v0.3.3 to v0.3.4.
- In the test.yml workflow, the version has been updated from v0.3.3 to v0.3.4.

These updates are necessary to ensure that the liquibase build-logic workflows are using the latest version and have the latest features and bug fixes.