### PR TITLE
DAT-15578      Change maven release perform on extensions build-logic

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.3.4
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.3.5
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.3.4
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.3.5
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -5,7 +5,11 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.3.4
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.3.5
     secrets: inherit

--- a/.github/workflows/snyk-nightly.yml
+++ b/.github/workflows/snyk-nightly.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   security-scan:
-    uses: liquibase/build-logic/.github/workflows/synk-nightly.yml@v0.3.4
+    uses: liquibase/build-logic/.github/workflows/synk-nightly.yml@v0.3.5
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,14 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     # This extension can not execute hibernete tests on Java 8/11. This needs to be fixed and then uncomment the following 2 lines and remove the build and unit-test logic from here
-    #uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.3.4
+    #uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.3.5
     #secrets: inherit
     name: Build & Package
     runs-on: ubuntu-latest
@@ -124,5 +128,5 @@ jobs:
             **/target/jacoco.exec
 
   dependabot:
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.3.5
     secrets: inherit


### PR DESCRIPTION
chore(workflows): update liquibase/build-logic workflows to v0.3.5 for attach-artifact-release, create-release, release-published, snyk-nightly, and test workflows

fix(workflows): add write permissions for contents and pull-requests in attach-artifact-release, create-release, release-published, and test workflows
fix(workflows): remove newline at end of file in snyk-nightly workflow
fix(workflows): update dependabot-automerge workflow to v0.3.5