### PR TITLE
DAT-16025 Allow releasing liquibase-hibernate5 alongside liquibase-hibernate6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.4.6
     secrets: inherit
     with:
-      java: '[11, 17, 18]'
+      java: '[17, 18]'
       os: '["ubuntu-latest", "windows-latest"]'
 
   hibernate-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,88 +13,16 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
-    # This extension can not execute hibernete tests on Java 8/11. This needs to be fixed and then uncomment the following 2 lines and remove the build and unit-test logic from here
-    #uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.3.5
-    #secrets: inherit
-    name: Build & Package
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Build and Package
-        run: mvn -B dependency:go-offline clean package -DskipTests=true
-
-      - name: Get Artifact ID
-        id: get-artifact-id
-        run: echo "::set-output name=artifact_id::$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
-
-      - name: Save Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts
-          path: |
-            target/*
-
-      - name: Save Event File
-        uses: actions/upload-artifact@v3
-        with:
-          name: Event File
-          path: ${{ github.event_path }}
-
-    outputs:
-      artifact_id: ${{ steps.get-artifact-id.outputs.artifact_id }}
-
-  unit-test:
-    name: Test Java ${{ matrix.java }}
-    runs-on: ubuntu-latest
-    needs: build
-
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ 17, 20 ]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Build Cache
-        uses: actions/cache@v3.3.2
-        with:
-          key: build-${{ github.run_number }}-${{ github.run_attempt }}
-          path: |
-            **/target/**
-            ~/.m2/repository/org/liquibase/
-
-      - name: Run Tests
-        run: mvn -B jacoco:prepare-agent surefire:test
-
-      - name: Archive Test Results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-reports-jdk-${{ matrix.java }}
-          path: |
-            **/target/surefire-reports
-            **/target/jacoco.exec
+  build-test:
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.4.6
+    secrets: inherit
+    with:
+      java: '[11, 17, 18]'
+      os: '["ubuntu-latest", "windows-latest"]'
 
   hibernate-test:
     name: Test Hibernate ${{ matrix.hibernate }}
-    needs: build
+    needs: build-test
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
https://datical.atlassian.net/browse/DAT-16025

chore(test.yml): update build-test job to use the latest version of the liquibase/build-logic action
chore(test.yml): remove unused permissions section from the workflow file
chore(test.yml): remove commented out code for hibernate tests on Java 8/11
chore(test.yml): remove build and unit-test logic from the build-test job
chore(test.yml): update build-test job to run on multiple versions of Java and operating systems
chore(test.yml): remove unit-test job as it is no longer needed
chore(test.yml): remove unused steps and artifacts from the build-test job
chore(test.yml): update hibernate-test job to depend on the build-test job instead of the build job