### PR TITLE
chore(release-published.yml): update release job to use specific vers…

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -10,6 +10,14 @@ permissions:
   pull-requests: write
   
 jobs:
-  release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.4.6
+  release-hibernate6:
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-16025
+    with:
+      branch: ${{ github.ref }}
+    secrets: inherit
+
+  release-hibernate5:
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-16025
+    with:
+      branch: 'refs/heads/hibernate5'
     secrets: inherit


### PR DESCRIPTION
…ion of extension-release-published.yml

chore(release-published.yml): add release-hibernate6 job to use extension-release-published.yml with branch dynamically set to the current branch

chore(release-published.yml): add release-hibernate5 job to use extension-release-published.yml with branch set to 'refs/heads/hibernate5'