### PR TITLE
chore(pom.xml): update liquibase-hibernate6 version from 4.24.4-SNAPS…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-hibernate6</artifactId>
-    <version>4.24.4-SNAPSHOT</version>
+    <version>4.24.2-SNAPSHOT</version>
 
     <name>Liquibase Hibernate Integration</name>
     <description>Liquibase extension for hibernate integration including generating changesets based on changed


### PR DESCRIPTION
…HOT to 4.24.2-SNAPSHOT for compatibility reasons