### PR TITLE
chore(release-published.yml): update branch names in workflow file fo…

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -13,11 +13,11 @@ jobs:
   release-hibernate6:
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-16025
     with:
-      branch: ${{ github.ref }}
+      branch: 'main'
     secrets: inherit
 
   release-hibernate5:
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-16025
     with:
-      branch: 'refs/heads/hibernate5'
+      branch: 'hibernate5'
     secrets: inherit


### PR DESCRIPTION
…r better readability and consistency

The branch name 'refs/heads/hibernate5' has been changed to 'hibernate5' to match the actual branch name. The branch name variable '${{ github.ref }}' has been changed to 'main' to explicitly specify the branch name.