### PR TITLE
Fixed Hyperlink in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Specify the Liquibase extension in the `<dependency>` section of your POM file b
 
 To file a bug, improve documentation, or contribute code, follow our [guidelines for contributing](https://www.liquibase.org/community). 
 
-[This step-by-step instructions](https://www.liquibase.org/community/contribute/code) will help you contribute code for the extension. 
+[This step-by-step instructions](https://www.liquibase.org/community-contributors/community-developers) will help you contribute code for the extension. 
 
 Once you have created a PR for this extension you can find the artifact for your build using the following link: [https://github.com/liquibase/liquibase-hibernate/actions/workflows/build.yml](https://github.com/liquibase/liquibase-hibernate/actions/workflows/build.yml).
 


### PR DESCRIPTION
This step-by-step hyperlink is broken in the ReadMe and throws Error 404

![image](https://github.com/liquibase/liquibase-hibernate/assets/74114936/2dafee7a-57ec-443b-8fe8-66db50d7daaa)

![image](https://github.com/liquibase/liquibase-hibernate/assets/74114936/89f2b2c6-616a-4001-be57-d1f25936fdc0)

Solution:
The initial link showed error 404 page , so redirected it to the https://www.liquibase.org/community-contributors/community-developers page.
