### PR TITLE
DAT-16417 Extensions nightly build review - hibernate5

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.5
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.8
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,51 @@
+# This workflow will build the extension against the latest Liquibase artifact
+name: "Nightly build"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 1-5'
+
+jobs:
+    nightly-build:
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
+      with:
+        nightly: true
+        java: '[11, 17]'
+        os: '["ubuntu-latest"]'
+      secrets: inherit
+
+    hibernate-test:
+      name: Test Hibernate ${{ matrix.hibernate }}
+      needs: nightly-build
+      runs-on: ubuntu-latest
+  
+      strategy:
+        fail-fast: false
+        matrix:
+          hibernate: [ "5.5.9.Final", "5.4.33.Final", "5.3.30.Final" ]
+  
+      steps:
+        - uses: actions/checkout@v4
+  
+        - name: Set up JDK
+          uses: actions/setup-java@v3
+          with:
+            java-version: 17
+            distribution: 'temurin'
+            cache: 'maven'
+  
+        - name: Run Compatibility Tests
+          run: mvn -B jacoco:prepare-agent surefire:test -Dhibernate.version=${{ matrix.hibernate }}
+  
+        - name: Run Tests
+          run: mvn -B jacoco:prepare-agent surefire:test
+  
+        - name: Archive Test Results
+          if: ${{ always() }}
+          uses: actions/upload-artifact@v3
+          with:
+            name: test-reports-hibernate-${{ matrix.hibernate }}
+            path: |
+              **/target/surefire-reports
+              **/target/jacoco.exec

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,5 +11,5 @@ permissions:
   
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.5
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.8
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-test:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
     secrets: inherit
     with:
       java: '[11, 17]'
@@ -57,5 +57,5 @@ jobs:
 
   dependabot:
     needs: hibernate-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.4.6
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.8
     secrets: inherit


### PR DESCRIPTION
chore(attach-artifact-release.yml): update liquibase/build-logic extension version to v0.5.8

feat(build-nightly.yml): add workflow for nightly build of the extension against the latest Liquibase artifact
chore(create-release.yml): update liquibase/build-logic extension version to v0.5.8
chore(test.yml): update liquibase/build-logic extension version to v0.5.8