### PR TITLE
fix diff changelog generating undesired changes

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedPrimaryKeyChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedPrimaryKeyChangeGenerator.java
@@ -7,18 +7,17 @@ import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
 import liquibase.ext.hibernate.database.HibernateDatabase;
 import liquibase.structure.DatabaseObject;
-import liquibase.structure.core.UniqueConstraint;
+import liquibase.structure.core.PrimaryKey;
 
 /**
- * Unique attribute for unique constraints backing index can have different values dependending on the database implementation,
- * so we suppress all unique constraint changes based on unique constraints.
-
+ * Hibernate doesn't know about all the variations that occur with primary keys, especially backing index stuff.
+ * To prevent changing customized primary keys, we suppress this kind of changes from hibernate side.
  */
-public class ChangedUniqueConstraintChangeGenerator extends liquibase.diff.output.changelog.core.ChangedUniqueConstraintChangeGenerator {
+public class ChangedPrimaryKeyChangeGenerator extends liquibase.diff.output.changelog.core.ChangedPrimaryKeyChangeGenerator {
 
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
-        if (UniqueConstraint.class.isAssignableFrom(objectType)) {
+        if (PrimaryKey.class.isAssignableFrom(objectType)) {
             return PRIORITY_ADDITIONAL;
         }
         return PRIORITY_NONE;
@@ -32,6 +31,7 @@ public class ChangedUniqueConstraintChangeGenerator extends liquibase.diff.outpu
                 return null;
             }
         }
+
         return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
     }
 }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
@@ -57,6 +57,11 @@ public class ChangedSequenceChangeGenerator extends liquibase.diff.output.change
         return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
     }
 
+
+    /**
+     * In some cases a value that was 1 can be null in the database, or the name field can be different only by case.
+     * This method removes these differences from the list of differences so we don't generate a change for them.
+     */
     private void advancedIgnoredDifferenceFields(ObjectDifferences differences, Database referenceDatabase, Database comparisonDatabase) {
         Set<String> ignoredDifferenceFields = new HashSet<>();
         for (Difference difference : differences.getDifferences()) {
@@ -64,7 +69,7 @@ public class ChangedSequenceChangeGenerator extends liquibase.diff.output.change
             String refValue = difference.getReferenceValue() != null ? difference.getReferenceValue().toString() : null;
             String comparedValue = difference.getComparedValue() != null ? difference.getComparedValue().toString() : null;
 
-            // if the name field case is different and the databases are case insensitive, we can ignore the difference
+            // if the name field case is different and the databases are case-insensitive, we can ignore the difference
             boolean isNameField = field.equals("name");
             boolean isCaseInsensitive = !referenceDatabase.isCaseSensitive() || !comparisonDatabase.isCaseSensitive();
 

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedSequenceChangeGenerator.java
@@ -74,11 +74,14 @@ public class ChangedSequenceChangeGenerator extends liquibase.diff.output.change
             boolean isCaseInsensitive = !referenceDatabase.isCaseSensitive() || !comparisonDatabase.isCaseSensitive();
 
             // if the startValue or incrementBy fields are 1 and the other is null, we can ignore the difference
+            // Or 50, as it is the default value for hibernate for allocationSize:
+            // https://github.com/hibernate/hibernate-orm/blob/bda95dfbe75c68f5c1b77a2f21c403cbe08548a2/hibernate-core/src/main/java/org/hibernate/boot/model/IdentifierGeneratorDefinition.java#L252
             boolean isStartOrIncrementField = field.equals("startValue") || field.equals("incrementBy");
-            boolean isOneAndNull = "1".equals(refValue) && comparedValue == null || refValue == null && "1".equals(comparedValue);
+            boolean isOneOrFiftyAndNull = "1".equals(refValue) && comparedValue == null || refValue == null && "1".equals(comparedValue) ||
+                    "50".equals(refValue) && comparedValue == null || refValue == null && "50".equals(comparedValue);
 
             if ((isNameField && isCaseInsensitive && refValue != null && refValue.equalsIgnoreCase(comparedValue)) ||
-                    (isStartOrIncrementField && isOneAndNull)) {
+                    (isStartOrIncrementField && isOneOrFiftyAndNull)) {
                 ignoredDifferenceFields.add(field);
             }
         }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
@@ -1,0 +1,32 @@
+package liquibase.ext.hibernate.diff;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.UniqueConstraint;
+
+public class ChangedUniqueConstraintChangeGenerator extends liquibase.diff.output.changelog.core.ChangedUniqueConstraintChangeGenerator {
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (UniqueConstraint.class.isAssignableFrom(objectType)) {
+            return PRIORITY_ADDITIONAL;
+        }
+        return PRIORITY_NONE;
+    }
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            differences.removeDifference("unique");
+            if (!differences.hasDifferences()) {
+                return null;
+            }
+        }
+        return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+    }
+}

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -14,7 +14,7 @@ import org.hibernate.HibernateException;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;=
+import java.security.NoSuchAlgorithmException;
 
 public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerator {
 
@@ -53,7 +53,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                 Index index = getBackingIndex(uniqueConstraint, hibernateTable, snapshot);
                 uniqueConstraint.setBackingIndex(index);
 
-                Scope.getCurrentScope().getLog(getClass()).info("Found unique constraint " + uniqueConstraint.toString());
+                Scope.getCurrentScope().getLog(getClass()).info("Found unique constraint " + uniqueConstraint);
                 table.getUniqueConstraints().add(uniqueConstraint);
             }
             for (var column : hibernateTable.getColumns()) {
@@ -67,7 +67,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
                     }
                     uniqueConstraint.addColumn(0, new Column(column.getName()).setRelation(table));
                     uniqueConstraint.setName(name);
-                    Scope.getCurrentScope().getLog(getClass()).info("Found unique constraint " + uniqueConstraint.toString());
+                    Scope.getCurrentScope().getLog(getClass()).info("Found unique constraint " + uniqueConstraint);
                     table.getUniqueConstraints().add(uniqueConstraint);
 
                     Index index = getBackingIndex(uniqueConstraint, hibernateTable, snapshot);
@@ -102,7 +102,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
         }
     }
 
-    protected Index getBackingIndex(UniqueConstraint uniqueConstraint, org.hibernate.mapping.Table hibernateTable, DatabaseSnapshot snapshot) {
+    protected Index getBackingIndex(UniqueConstraint uniqueConstraint, org.hibernate.mapping.Table hibernateTable) {
         Index index = new Index();
         index.setRelation(uniqueConstraint.getRelation());
         index.setColumns(uniqueConstraint.getColumns());

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -24,6 +24,10 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
 
     @Override
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
+        UniqueConstraint exampleUniqueConstraint = (UniqueConstraint) example;
+        if (exampleUniqueConstraint.getBackingIndex() != null) {
+            exampleUniqueConstraint.getBackingIndex().setUnique(true);
+        }
         return example;
     }
 
@@ -106,7 +110,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
         Index index = new Index();
         index.setRelation(uniqueConstraint.getRelation());
         index.setColumns(uniqueConstraint.getColumns());
-        index.setUnique(false);
+        index.setUnique(true);
         index.setName(String.format("%s_%s_IX",hibernateTable.getName(), StringUtil.randomIdentifer(4)));
 
         return index;

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -14,7 +14,7 @@ import org.hibernate.HibernateException;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchAlgorithmException;=
 
 public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerator {
 
@@ -24,10 +24,6 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
 
     @Override
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        UniqueConstraint exampleUniqueConstraint = (UniqueConstraint) example;
-        if (exampleUniqueConstraint.getBackingIndex() != null) {
-            exampleUniqueConstraint.getBackingIndex().setUnique(true);
-        }
         return example;
     }
 

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -15,7 +15,6 @@ import org.hibernate.HibernateException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Iterator;
 
 public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerator {
 
@@ -107,7 +106,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
         Index index = new Index();
         index.setRelation(uniqueConstraint.getRelation());
         index.setColumns(uniqueConstraint.getColumns());
-        index.setUnique(true);
+        index.setUnique(false);
         index.setName(String.format("%s_%s_IX",hibernateTable.getName(), StringUtil.randomIdentifer(4)));
 
         return index;

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -102,7 +102,7 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
         }
     }
 
-    protected Index getBackingIndex(UniqueConstraint uniqueConstraint, org.hibernate.mapping.Table hibernateTable) {
+    protected Index getBackingIndex(UniqueConstraint uniqueConstraint, org.hibernate.mapping.Table hibernateTable, DatabaseSnapshot snapshot) {
         Index index = new Index();
         index.setRelation(uniqueConstraint.getRelation());
         index.setColumns(uniqueConstraint.getColumns());

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -1,5 +1,6 @@
 liquibase.ext.hibernate.diff.ChangedColumnChangeGenerator
 liquibase.ext.hibernate.diff.ChangedForeignKeyChangeGenerator
+liquibase.ext.hibernate.diff.ChangedPrimaryKeyChangeGenerator
 liquibase.ext.hibernate.diff.ChangedSequenceChangeGenerator
 liquibase.ext.hibernate.diff.ChangedUniqueConstraintChangeGenerator
 liquibase.ext.hibernate.diff.MissingSequenceChangeGenerator

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -1,5 +1,6 @@
 liquibase.ext.hibernate.diff.ChangedColumnChangeGenerator
 liquibase.ext.hibernate.diff.ChangedForeignKeyChangeGenerator
 liquibase.ext.hibernate.diff.ChangedSequenceChangeGenerator
+liquibase.ext.hibernate.diff.ChangedUniqueConstraintChangeGenerator
 liquibase.ext.hibernate.diff.MissingSequenceChangeGenerator
 liquibase.ext.hibernate.diff.UnexpectedIndexChangeGenerator


### PR DESCRIPTION
Hibernate doesn't know about all the variations that occur with primary keys/sequences/unique constrains, especially backing index stuff.
To prevent unexpected changesets to be generated we suppress this kind of changes.

- Fixes #436 
- Fixes #162
- Fixes #173
- Fixes #219
- Fixes #456
- Fixes #500

PR https://github.com/liquibase/liquibase/pull/5792  also helps.