### PR TITLE
Enables catalog support for HibernateDatabase so that diff-changelog generation works again

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
@@ -331,7 +331,7 @@ public abstract class HibernateDatabase extends AbstractJdbcDatabase {
 
     @Override
     public boolean supportsCatalogs() {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
This PR fixes #716

Before this change, running diff-changelog simply doesn't create a changelog file, because all changes won't be output.
With this change, the changelog generation works again, as it did in versions 4.27.0 and before.

See also the discussion in https://github.com/liquibase/liquibase-hibernate/issues/708 i think that this issue is related.