### PR TITLE
fix: update filename used in badge to show nightly build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Liquibase Hibernate Integration [![Build and Test Extension](https://github.com/liquibase/liquibase-hibernate/actions/workflows/build.yml/badge.svg)](https://github.com/liquibase/liquibase-hibernate/actions/workflows/build.yml)
+# Liquibase Hibernate Integration [![Build and Test Extension](https://github.com/liquibase/liquibase-hibernate/actions/workflows/build-nightly.yml/badge.svg)](https://github.com/liquibase/liquibase-hibernate/actions/workflows/build.yml)
 
 This is a Liquibase extension for connecting to Hibernate. The extension lets you use your Hibernate configuration as a comparison database for diff, diffChangeLog, and generateChangeLog in Liquibase.
 


### PR DESCRIPTION
The file being referenced was incorrect. This fixes the name so the workflow status badge shows again.