### PR TITLE
Implement support for hibernate timestamp columns with timezone

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGenerator.java
@@ -183,7 +183,11 @@ public class ColumnSnapshotGenerator extends HibernateSnapshotGenerator {
         if (!matcher.matches()) {
             return null;
         }
-        DataType dataType = new DataType(matcher.group(1));
+        String typeName = matcher.group(1);
+        if (hibernateType.endsWith("with time zone")) {
+            typeName += " with timezone";
+        }
+        DataType dataType = new DataType(typeName);
         if (matcher.group(3).isEmpty()) {
             if (!matcher.group(2).isEmpty()) {
                 dataType.setColumnSize(Integer.parseInt(matcher.group(2)));
@@ -199,6 +203,8 @@ public class ColumnSnapshotGenerator extends HibernateSnapshotGenerator {
                 dataType.setColumnSizeUnit(DataType.ColumnSizeUnit.CHAR);
             }
         }
+
+        Scope.getCurrentScope().getLog(getClass()).info("Converted column data type - hibernate type: " + hibernateType + ", SQL type: " + sqlTypeCode + ", type name: " + typeName);
 
         dataType.setDataTypeId(sqlTypeCode);
         return dataType;

--- a/src/test/java/com/example/timezone/Item.java
+++ b/src/test/java/com/example/timezone/Item.java
@@ -1,0 +1,51 @@
+package com.example.timezone;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@Entity
+public class Item {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private long id;
+
+    @Column
+    private Instant timestamp1;
+
+    @Column
+    private LocalDateTime timestamp2;
+
+    @Column(columnDefinition = "timestamp")
+    private Instant timestamp3;
+
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    private LocalDateTime timestamp4;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Instant getTimestamp1() {
+        return timestamp1;
+    }
+
+    public void setTimestamp1(Instant timestamp1) {
+        this.timestamp1 = timestamp1;
+    }
+
+    public LocalDateTime getTimestamp2() {
+        return timestamp2;
+    }
+
+    public void setTimestamp2(LocalDateTime timestamp2) {
+        this.timestamp2 = timestamp2;
+    }
+
+}

--- a/src/test/java/com/example/timezone/Item.java
+++ b/src/test/java/com/example/timezone/Item.java
@@ -48,4 +48,20 @@ public class Item {
         this.timestamp2 = timestamp2;
     }
 
+    public Instant getTimestamp3() {
+        return timestamp3;
+    }
+
+    public void setTimestamp3(Instant timestamp3) {
+        this.timestamp3 = timestamp3;
+    }
+
+    public LocalDateTime getTimestamp4() {
+        return timestamp4;
+    }
+
+    public void setTimestamp4(LocalDateTime timestamp4) {
+        this.timestamp4 = timestamp4;
+    }
+
 }

--- a/src/test/java/liquibase/ext/hibernate/snapshot/TimezoneSnapshotTest.java
+++ b/src/test/java/liquibase/ext/hibernate/snapshot/TimezoneSnapshotTest.java
@@ -1,0 +1,66 @@
+package liquibase.ext.hibernate.snapshot;
+
+import liquibase.CatalogAndSchema;
+import liquibase.database.Database;
+import liquibase.integration.commandline.CommandLineUtils;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotControl;
+import liquibase.snapshot.SnapshotGeneratorFactory;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.DataType;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class TimezoneSnapshotTest {
+
+    @Test
+    public void testTimezoneColumns() throws Exception {
+        Database database = CommandLineUtils.createDatabaseObject(new ClassLoaderResourceAccessor(this.getClass().getClassLoader()), "hibernate:spring:com.example.timezone?dialect=org.hibernate.dialect.H2Dialect", null, null, null, null, null, false, false, null, null, null, null, null, null, null);
+
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, database, new SnapshotControl(database));
+
+        assertThat(
+                snapshot.get(Column.class),
+                hasItems(
+                        // Instant colum should result in 'timestamp with timezone' type
+                        allOf(
+                                hasProperty("name", equalTo("timestamp1")),
+                                hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalTo("timestamp with timezone")))
+                        ),
+                        // LocalDateTime colum should result in 'timestamp' type
+                        allOf(
+                                hasProperty("name", equalTo("timestamp2")),
+                                hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalTo("timestamp")))
+                        ),
+                        // Colum with explicit definition
+                        allOf(
+                                hasProperty("name", equalTo("timestamp3")),
+                                hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalTo("timestamp")))
+                        ),
+                        // Colum with explicit definition
+                        allOf(
+                                hasProperty("name", equalTo("timestamp4")),
+                                hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalToIgnoringCase("timestamp with timezone")))
+                        )
+                )
+        );
+    }
+
+    private static <T> FeatureMatcher<DatabaseObject, T> hasDatabaseAttribute(String attribute, Class<T> type, Matcher<T> matcher) {
+        return new FeatureMatcher<>(matcher, attribute, attribute) {
+
+            @Override
+            protected T featureValueOf(DatabaseObject databaseObject) {
+                return databaseObject.getAttribute(attribute, type);
+            }
+
+        };
+    }
+
+}

--- a/src/test/java/liquibase/ext/hibernate/snapshot/TimezoneSnapshotTest.java
+++ b/src/test/java/liquibase/ext/hibernate/snapshot/TimezoneSnapshotTest.java
@@ -28,22 +28,22 @@ public class TimezoneSnapshotTest {
         assertThat(
                 snapshot.get(Column.class),
                 hasItems(
-                        // Instant colum should result in 'timestamp with timezone' type
+                        // Instant column should result in 'timestamp with timezone' type
                         allOf(
                                 hasProperty("name", equalTo("timestamp1")),
                                 hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalTo("timestamp with timezone")))
                         ),
-                        // LocalDateTime colum should result in 'timestamp' type
+                        // LocalDateTime column should result in 'timestamp' type
                         allOf(
                                 hasProperty("name", equalTo("timestamp2")),
                                 hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalTo("timestamp")))
                         ),
-                        // Colum with explicit definition
+                        // Instant column with explicit definition 'timestamp' should result in 'timestamp' type
                         allOf(
                                 hasProperty("name", equalTo("timestamp3")),
                                 hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalTo("timestamp")))
                         ),
-                        // Colum with explicit definition
+                        // LocalDateTime Colum with explicit definition 'TIMESTAMP WITH TIME ZONE' should result in 'TIMESTAMP with timezone' type
                         allOf(
                                 hasProperty("name", equalTo("timestamp4")),
                                 hasDatabaseAttribute("type", DataType.class, hasProperty("typeName", equalToIgnoringCase("timestamp with timezone")))


### PR DESCRIPTION
Since version 5 or 6, Hibernate started adding the `with time zone` suffix to columns of certain types.
This PR aims to correctly transfer the `with time zone` suffix from Hibernate to the corresponding Liquibase format `with timezone`.  