### PR TITLE
Test support versions updated

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          hibernate: [ "6.0.2.Final", "6.1.7.Final", "6.2.7.Final", "6.3.1.Final" ]
+          hibernate: [ "6.2.7.Final", "6.3.1.Final" ]
   
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       fail-fast: false
       matrix:
         hibernate: [ "6.2.7.Final", "6.3.1.Final" ]
-        #Removing test support for versions "6.0.2.Final" and "6.1.7.Final" since they are not compatible with current liquibase version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hibernate: [ "6.0.2.Final", "6.1.7.Final", "6.2.7.Final", "6.3.1.Final" ]
+        hibernate: [ "6.2.7.Final", "6.3.1.Final" ]
+        #Removing test support for versions "6.0.2.Final" and "6.1.7.Final" since they are not compatible with current liquibase version
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Test support for versions "6.0.2.Final" and "6.1.7 has been removed since they are not compatible with the current liquibase version, and this is causing some compilation errors. 