### PR TITLE
Add enum support for H2 / MySql to ColumnSnapshotGenerator

### DIFF
--- a/src/test/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGeneratorTest.java
+++ b/src/test/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGeneratorTest.java
@@ -2,6 +2,7 @@ package liquibase.ext.hibernate.snapshot;
 
 import liquibase.exception.DatabaseException;
 import liquibase.structure.core.DataType;
+import org.hibernate.type.SqlTypes;
 import org.junit.Test;
 
 import java.sql.Types;
@@ -27,5 +28,11 @@ public class ColumnSnapshotGeneratorTest {
         assertEquals(30, varcharChar.getColumnSize().intValue());
         assertEquals(DataType.ColumnSizeUnit.CHAR, varcharChar.getColumnSizeUnit());
 
+
+        DataType enumType = columnSnapshotGenerator.toDataType("enum ('a', 'b', 'c')", SqlTypes.ENUM);
+        assertEquals("enum ('a', 'b', 'c')", enumType.getTypeName());
+        assertNull(enumType.getColumnSize());
+        assertEquals(SqlTypes.ENUM, enumType.getDataTypeId().intValue());
+        assertNull(enumType.getColumnSizeUnit());
     }
 }


### PR DESCRIPTION
As described in liquibase issues [ #6482](https://github.com/liquibase/liquibase/issues/6482) and [#6585](https://github.com/liquibase/liquibase/issues/6585), when generating a changelog for databased types of MySQL and H2 using liquibase-hibernate, the enum syntax is incorrect. This PR works around the issue until support has been added to the liquibase core