### PR TITLE
fix: Implement missing replaces() method in all snapshot generators

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/CatalogSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/CatalogSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.ext.hibernate.snapshot;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Catalog;
 
@@ -26,4 +27,8 @@ public class CatalogSnapshotGenerator extends HibernateSnapshotGenerator {
         // Nothing to add to
     }
 
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{liquibase.snapshot.jvm.CatalogSnapshotGenerator.class};
+    }
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGenerator.java
@@ -1,11 +1,11 @@
 package liquibase.ext.hibernate.snapshot;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import liquibase.snapshot.SnapshotGenerator;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
@@ -224,6 +224,11 @@ public class ColumnSnapshotGenerator extends HibernateSnapshotGenerator {
 
         dataType.setDataTypeId(sqlTypeCode);
         return dataType;
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{liquibase.snapshot.jvm.ColumnSnapshotGenerator.class};
     }
 
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/ForeignKeySnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/ForeignKeySnapshotGenerator.java
@@ -5,6 +5,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.ext.hibernate.database.HibernateDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.Table;
@@ -83,6 +84,11 @@ public class ForeignKeySnapshotGenerator extends HibernateSnapshotGenerator {
                 }
             }
         }
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ liquibase.snapshot.jvm.ForeignKeySnapshotGenerator.class };
     }
 
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java
@@ -4,6 +4,7 @@ import liquibase.Scope;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
 
@@ -90,5 +91,10 @@ public class IndexSnapshotGenerator extends HibernateSnapshotGenerator {
             */
             return false;
         }
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{liquibase.snapshot.jvm.IndexSnapshotGenerator.class};
     }
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/PrimaryKeySnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/PrimaryKeySnapshotGenerator.java
@@ -4,6 +4,7 @@ import liquibase.Scope;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Index;
@@ -65,6 +66,11 @@ public class PrimaryKeySnapshotGenerator extends HibernateSnapshotGenerator {
                 table.getIndexes().add(index);
             }
         }
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{liquibase.snapshot.jvm.PrimaryKeySnapshotGenerator.class};
     }
 
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/SchemaSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/SchemaSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.ext.hibernate.snapshot;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Catalog;
 import liquibase.structure.core.Schema;
@@ -24,6 +25,11 @@ public class SchemaSnapshotGenerator extends HibernateSnapshotGenerator {
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
         // Nothing to do
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{liquibase.snapshot.jvm.SchemaSnapshotGenerator.class};
     }
 
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/SequenceSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/SequenceSnapshotGenerator.java
@@ -4,6 +4,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.ext.hibernate.database.HibernateDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Sequence;
@@ -46,6 +47,8 @@ public class SequenceSnapshotGenerator extends HibernateSnapshotGenerator {
         }
     }
 
-
-
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ liquibase.snapshot.jvm.SequenceSnapshotGenerator.class };
+    }
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/TableSnapshotGenerator.java
@@ -7,6 +7,7 @@ import liquibase.ext.hibernate.snapshot.extension.ExtendedSnapshotGenerator;
 import liquibase.ext.hibernate.snapshot.extension.TableGeneratorSnapshotGenerator;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
@@ -117,5 +118,10 @@ public class TableSnapshotGenerator extends HibernateSnapshotGenerator {
         joinTable.setSchema(schema);
         Scope.getCurrentScope().getLog(getClass()).info("Found table " + joinTable.getName());
         schema.addDatabaseObject(snapshotObject(joinTable, snapshot));
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{liquibase.snapshot.jvm.TableSnapshotGenerator.class};
     }
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/UniqueConstraintSnapshotGenerator.java
@@ -4,6 +4,7 @@ import liquibase.Scope;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Index;
@@ -110,6 +111,11 @@ public class UniqueConstraintSnapshotGenerator extends HibernateSnapshotGenerato
         index.setName(String.format("%s_%s_IX",hibernateTable.getName(), StringUtil.randomIdentifer(4)));
 
         return index;
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ liquibase.snapshot.jvm.UniqueConstraintSnapshotGenerator.class };
     }
 
 }

--- a/src/main/java/liquibase/ext/hibernate/snapshot/ViewSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/ViewSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.ext.hibernate.snapshot;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.View;
@@ -24,7 +25,11 @@ public class ViewSnapshotGenerator extends HibernateSnapshotGenerator {
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
         // No views in Hibernate mapping
+    }
 
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ liquibase.snapshot.jvm.ViewSnapshotGenerator.class };
     }
 
 }


### PR DESCRIPTION

Add overridden replaces() method to all Hibernate snapshot generator classes to
explicitly replace the corresponding snapshot generators from core Liquibase.
This ensures that Liquibase uses the Hibernate-specific implementations instead
of the default ones.

This fix necessary after the improvement from https://github.com/liquibase/liquibase/pull/5775/ 