### PR TITLE
chore(workflows): remove push trigger and permissions from workflows

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types:
       - closed
-  push:
-    branches:
-      - main
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,6 @@ on:
       - opened
       - reopened
       - synchronize
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
 
@@ -21,7 +14,7 @@ jobs:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: "true"
 
   build-test:
     needs: authorize


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to streamline their triggers and permissions. The most significant changes include removing the `push` event triggers and adjusting permissions and syntax in the `test.yml` workflow.

### Workflow Trigger Updates:
* [`.github/workflows/attach-artifact-release.yml`](diffhunk://#diff-4e6cdd9dccb26ce28aa3716a4046b99dd39c69e9319bf6b4e2922e6309c13b4aL7-L9): Removed the `push` event trigger for the `main` branch, leaving only the `pull_request` event with the `closed` type.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-R17): Removed the `push` event trigger for the `main` branch and its associated permissions.

### Syntax and Permissions Adjustment:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-R17): Changed the `run` command in the `authorize` job from `true` to `"true"` for consistency in syntax.