### PR TITLE
DAT-21010: Add Java 25 to github builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -11,7 +11,7 @@ jobs:
       uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
       with:
         nightly: true
-        java: '[17, 21]'
+        java: '[17, 21, 25]'
         os: '["ubuntu-latest"]'
       secrets: inherit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     secrets: inherit
     with:
-      java: '[17, 21]'
+      java: '[17, 21, 25]'
       os: '["ubuntu-latest"]'
 
   hibernate-test:


### PR DESCRIPTION
This PR adds Java 25 to the matrix configuration for Java version testing in GitHub Actions workflows.

## Changes
- Updated workflow files to include Java 25 in the matrix strategy
- Ensures compatibility testing with Java 25 alongside existing versions (11, 17, 21)

## Related
- Jira Ticket: [DAT-21010](https://datical.atlassian.net/browse/DAT-21010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)