### PR TITLE
Fix #794: allow use of hibernate.default_schema instead of hardcoded 'HIBERNATE'

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateDatabase.java
@@ -249,10 +249,10 @@ public abstract class HibernateDatabase extends AbstractJdbcDatabase {
         if (dialect instanceof MySQLDialect) {
             indexesForForeignKeys = true;
         }
-        if(getProperty(AvailableSettings.DEFAULT_SCHEMA) != null){
+        /* if(getProperty(AvailableSettings.DEFAULT_SCHEMA) != null){
             setDefaultSchemaName(getProperty(AvailableSettings.DEFAULT_SCHEMA));
             setDefaultCatalogName(getProperty(AvailableSettings.DEFAULT_CATALOG));
-        }
+        }*/
     }
 
 
@@ -306,14 +306,12 @@ public abstract class HibernateDatabase extends AbstractJdbcDatabase {
 
     @Override
     public String getDefaultSchemaName() {
-        String configuredSchema = getProperty(AvailableSettings.DEFAULT_SCHEMA);
-        return configuredSchema != null ? configuredSchema : DEFAULT_SCHEMA;
+        return getProperty(AvailableSettings.DEFAULT_SCHEMA) != null ? getProperty(AvailableSettings.DEFAULT_SCHEMA) : DEFAULT_SCHEMA;
     }
 
     @Override
     public String getDefaultCatalogName() {
-        String configuredSchema = getProperty(AvailableSettings.DEFAULT_SCHEMA);
-        return configuredSchema != null ? configuredSchema : DEFAULT_SCHEMA;
+        return getProperty(AvailableSettings.DEFAULT_CATALOG) != null ? getProperty(AvailableSettings.DEFAULT_CATALOG) : getDefaultSchemaName();
     }
 
     @Override

--- a/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
+++ b/src/main/java/liquibase/ext/hibernate/database/HibernateSpringPackageDatabase.java
@@ -99,6 +99,7 @@ public class HibernateSpringPackageDatabase extends JpaPersistenceDatabase {
         map.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, Boolean.FALSE.toString());
         map.put(AvailableSettings.PHYSICAL_NAMING_STRATEGY, getHibernateConnection().getProperties().getProperty(AvailableSettings.PHYSICAL_NAMING_STRATEGY));
         map.put(AvailableSettings.IMPLICIT_NAMING_STRATEGY, getHibernateConnection().getProperties().getProperty(AvailableSettings.IMPLICIT_NAMING_STRATEGY));
+        map.put(AvailableSettings.DEFAULT_CATALOG, getHibernateConnection().getProperties().getProperty(AvailableSettings.DEFAULT_CATALOG));
         map.put(AvailableSettings.DEFAULT_SCHEMA, getHibernateConnection().getProperties().getProperty(AvailableSettings.DEFAULT_SCHEMA));
         map.put(AvailableSettings.SCANNER_DISCOVERY, "");	// disable scanning of all classes and hbm.xml files. Only scan speficied packages
         map.put(EnversSettings.AUDIT_TABLE_PREFIX,getHibernateConnection().getProperties().getProperty(EnversSettings.AUDIT_TABLE_PREFIX,""));


### PR DESCRIPTION
Changes in this PR:
- HibernateDatabase now respects hibernate.default_schema
- Defaults to 'HIBERNATE' if property is not set

This fixes issue #794.