### PR TITLE
Feature/liquibase oss hibernate7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     </parent>
 
     <groupId>org.liquibase.ext</groupId>
-    <artifactId>liquibase-hibernate7</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <artifactId>liquibase-hibernate7-oss</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
 
     <name>Liquibase Hibernate Integration</name>
     <description>Liquibase extension for hibernate integration including generating changesets based on changed

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <hibernate.version>7.3.0.Final</hibernate.version>
         <spring.version>7.0.2</spring.version>
         <hibernate.models.version>1.1.0</hibernate.models.version>
-        <liquibase.version>5.0.2</liquibase.version>
+        <liquibase.version>4.28.0</liquibase.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>


### PR DESCRIPTION
### Subject: Add Hibernate 7 support for Liquibase 4.x (Stability Track)

#### Description
This PR introduces a new artifact, `liquibase-hibernate7-oss`, designed to provide **Hibernate 7 (Jakarta EE 10+)** compatibility for users remaining on the **Liquibase 4.x** core engine.

While the `main` branch moves toward a Liquibase 5.x baseline, there is a significant community requirement—specifically within the **Apache Grails Project** and similar long-term stable frameworks—to adopt Hibernate 7 without immediately migrating the underlying database migration engine.

#### Rationale for the "Stability Track"
Providing a Hibernate 7 integration that targets the Liquibase 4.x API offers several key benefits to the community:
* **Checksum Continuity:** It allows users to upgrade their ORM layer to Hibernate 7 while maintaining **Checksum Version 8** stability, avoiding mandatory checksum resets often required by a Liquibase 5 upgrade.
* **Framework Compatibility:** It ensures that frameworks that currently bundle and rely on Liquibase 4.x can offer their users the latest Hibernate features without a breaking change to the migration engine.
* **Standardized Naming:** By using the `-oss` suffix for this branch/artifact, we maintain a clear distinction between the **Stability Track (L4)** and the **Modern Track (L5/main)**, allowing users to choose the path that fits their CI/CD requirements.

#### Key Changes
* Created the `liquibase-hibernate7-oss` artifact.
* Backported Hibernate 7 support logic to be compatible with Liquibase 4.x APIs.
* Updated the `README.md` with a compatibility matrix to guide users between the L4 and L5 tracks.

#### Testing
Verified using the [Liquibase Test Harness](https://github.com/liquibase/liquibase-test-harness) to ensure that diff and changelog generation for Hibernate 7 entities remain consistent with Liquibase 4.x expectations.