### PR TITLE
fix: Hibernate 7.1/7.2 compatibility for getMemberDetails()

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/ColumnSnapshotGenerator.java
@@ -162,14 +162,14 @@ public class ColumnSnapshotGenerator extends HibernateSnapshotGenerator {
                         if (persistentClass != null) {
                             var rootClass = persistentClass.getRootClass();
                             var identifierProperty = rootClass.getIdentifierProperty();
-                            var memberDetails = simpleValue.getMemberDetails();
+                            var memberDetails = getMemberDetails(simpleValue);
 
                             // Detection of Generation Intent:
                             // For annotation-based entities, if @GeneratedValue is absent the ID
                             // is application-assigned and no generator should be created.
                             // For XML-mapped entities (memberDetails is null), we always process
                             // the generator since the intent is declared in the hbm.xml mapping.
-                            boolean hasGeneratedValue = memberDetails == null || memberDetails.hasDirectAnnotationUsage(jakarta.persistence.GeneratedValue.class);
+                            boolean hasGeneratedValue = memberDetails == null || hasAnnotation(memberDetails, jakarta.persistence.GeneratedValue.class);
 
                             if (hasGeneratedValue) {
                                 var generatorSettings = createGeneratorSettings(simpleValue);
@@ -310,6 +310,35 @@ public class ColumnSnapshotGenerator extends HibernateSnapshotGenerator {
         } catch (ReflectiveOperationException | RuntimeException e) {
             Scope.getCurrentScope().getLog(getClass()).fine("Could not access NativeGenerator delegate", e);
             return null;
+        }
+    }
+
+    /**
+     * Returns member details via reflection, for compatibility with Hibernate < 7.3
+     * where SimpleValue.getMemberDetails() does not exist.
+     */
+    private Object getMemberDetails(SimpleValue simpleValue) {
+        try {
+            var method = SimpleValue.class.getMethod("getMemberDetails");
+            return method.invoke(simpleValue);
+        } catch (NoSuchMethodException e) {
+            return null;
+        } catch (ReflectiveOperationException e) {
+            Scope.getCurrentScope().getLog(getClass()).fine("Could not get member details", e);
+            return null;
+        }
+    }
+
+    /**
+     * Checks for an annotation on member details via reflection, for compatibility
+     * with Hibernate < 7.3 where MemberDetails may not be available.
+     */
+    private boolean hasAnnotation(Object memberDetails, Class<? extends java.lang.annotation.Annotation> annotationType) {
+        try {
+            var method = memberDetails.getClass().getMethod("hasDirectAnnotationUsage", Class.class);
+            return (boolean) method.invoke(memberDetails, annotationType);
+        } catch (ReflectiveOperationException e) {
+            return true; // assume yes when we can't determine
         }
     }
 

--- a/src/main/java/liquibase/ext/hibernate/snapshot/SequenceSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/snapshot/SequenceSnapshotGenerator.java
@@ -82,12 +82,12 @@ public class SequenceSnapshotGenerator extends HibernateSnapshotGenerator {
             }
 
             try {
-                var memberDetails = simpleValue.getMemberDetails();
+                var memberDetails = getMemberDetails(simpleValue);
                 // Detection of Generation Intent:
                 // For annotation-based entities, only create a sequence snapshot if
                 // @GeneratedValue is present. For XML-mapped entities (memberDetails
                 // is null), always process since intent is declared in the mapping.
-                if (memberDetails != null && !memberDetails.hasDirectAnnotationUsage(jakarta.persistence.GeneratedValue.class)) {
+                if (memberDetails != null && !hasAnnotation(memberDetails, jakarta.persistence.GeneratedValue.class)) {
                     continue;
                 }
 
@@ -140,6 +140,27 @@ public class SequenceSnapshotGenerator extends HibernateSnapshotGenerator {
             Scope.getCurrentScope().getLog(getClass()).fine(
                     "Could not access NativeGenerator delegate", e);
             return null;
+        }
+    }
+
+    private Object getMemberDetails(SimpleValue simpleValue) {
+        try {
+            var method = SimpleValue.class.getMethod("getMemberDetails");
+            return method.invoke(simpleValue);
+        } catch (NoSuchMethodException e) {
+            return null;
+        } catch (ReflectiveOperationException e) {
+            Scope.getCurrentScope().getLog(getClass()).fine("Could not get member details", e);
+            return null;
+        }
+    }
+
+    private boolean hasAnnotation(Object memberDetails, Class<? extends java.lang.annotation.Annotation> annotationType) {
+        try {
+            var method = memberDetails.getClass().getMethod("hasDirectAnnotationUsage", Class.class);
+            return (boolean) method.invoke(memberDetails, annotationType);
+        } catch (ReflectiveOperationException e) {
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- The post-release job for 5.0.2-rc1 failed because `SimpleValue.getMemberDetails()` was added in Hibernate 7.3.0 and doesn't exist in 7.1.x/7.2.x
- Replaced direct calls with reflection-based fallback that returns null when the method is unavailable
- When null, the safe default applies: always process the generator (same behavior as before the `@GeneratedValue` intent detection was added)

## Test plan
- [x] 28 tests pass on Hibernate 7.3.1 (default)
- [x] 28 tests pass on Hibernate 7.2.4
- [x] 28 tests pass on Hibernate 7.1.16
- [ ] CI build passes (including post-release Hibernate matrix)