### PR TITLE
chore: prepare 5.0.3 release for hibernate6

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 
-name-template: 'Support for Liquibase Hibernate Extension v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: 'Liquibase Hibernate 6 v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION-hibernate6'
 exclude-labels:
   - 'skipReleaseNotes'
 categories:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-hibernate6</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.0.3-SNAPSHOT</version>
 
     <name>Liquibase Hibernate Integration</name>
     <description>Liquibase extension for hibernate integration including generating changesets based on changed


### PR DESCRIPTION
## Summary
Prepares the H6 5.0.3 release, matching the version of the liquibase-hibernate7 5.0.3 release on main.

- **`.github/release-drafter.yml`**: change `tag-template` to `v$RESOLVED_VERSION-hibernate6` and `name-template` to `Liquibase Hibernate 6 v$RESOLVED_VERSION`. Required because the plain `v5.0.3` tag already exists for hibernate7 — GitHub tags must be unique per repo.
- **`pom.xml`**: bump version `5.1.0-SNAPSHOT` → `5.0.3-SNAPSHOT` so `mvn release:prepare` (run by `extension-attach-artifact-release.yml`) derives `5.0.3` as the release version, producing Maven Central artifact `liquibase-hibernate6:5.0.3`.

## Release sequence after merge
1. Run `create-release.yml` via `workflow_dispatch` on `hibernate6` → release-drafter creates a draft. Verify tag is `v5.0.3-hibernate6`; if release-drafter computed a different version, edit the draft in GH UI before publishing.
2. Run `attach-artifact-release.yml` via `workflow_dispatch` on `hibernate6` → builds and signs the jar against pom 5.0.3, attaches to the draft.
3. Review the draft, click **Publish**.
4. `release-published.yml` (fires from `main` per GitHub release-event quirk) checks out the `v5.0.3-hibernate6` tag and publishes `liquibase-hibernate6:5.0.3` to Sonatype/Maven Central.
5. `liquibase-workflows[bot]` should open a follow-up version-bump PR for the next snapshot (similar to #886 for H7).

## Test plan
- [ ] CI passes on the PR (test.yml, codeql.yml against H6 versions 6.2.7, 6.3.1, 6.6.1)
- [ ] After merge, draft is created with tag `v5.0.3-hibernate6` and name `Liquibase Hibernate 6 v5.0.3`
- [ ] Attached jar manifest reports version `5.0.3`
- [ ] After publish, Maven Central shows `liquibase-hibernate6:5.0.3`