### PR TITLE
feat: add manual publish-to-sonatype workflow

### DIFF
--- a/.github/workflows/publish-to-sonatype.yml
+++ b/.github/workflows/publish-to-sonatype.yml
@@ -1,0 +1,91 @@
+name: Publish to Sonatype (manual)
+
+# Manual publish workflow for parallel-branch releases (e.g. hibernate6)
+# where the GitHub tag has a suffix that the standard
+# extension-release-published.yml can't strip cleanly.
+#
+# Downloads artifacts attached to a draft/published release by tag,
+# then calls build-logic's publish-to-central-portal action with the
+# clean Maven version supplied as a separate input.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "GitHub release tag to download artifacts from (e.g. v5.0.3-hibernate6)"
+        required: true
+        type: string
+      version:
+        description: "Maven Central artifact version (e.g. 5.0.3) — used for file matching and deployment metadata"
+        required: true
+        type: string
+      javaBuildVersion:
+        description: "Java version for the publish step"
+        required: false
+        default: "21"
+        type: string
+      artifactPath:
+        description: "Directory to download release artifacts into"
+        required: false
+        default: "."
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.javaBuildVersion }}
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        with:
+          gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+
+      - name: Checkout build-logic for publish action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: liquibase/build-logic
+          ref: main
+          path: build-logic
+          sparse-checkout: .github/actions/publish-to-central-portal
+
+      - name: Download Release Artifacts
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        with:
+          tag: ${{ inputs.tag }}
+          fileName: "*"
+          out-file-path: ${{ inputs.artifactPath }}
+
+      - name: Publish to Central Portal
+        uses: ./build-logic/.github/actions/publish-to-central-portal
+        with:
+          artifacts-dir: ${{ inputs.artifactPath }}
+          version: ${{ inputs.version }}
+          sonatype-username: ${{ env.SONATYPE_USERNAME }}
+          sonatype-token: ${{ env.SONATYPE_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a `workflow_dispatch`-only workflow that publishes a GitHub release's artifacts to Sonatype Central Portal, taking the GitHub release (by ID or tag) and Maven version as **separate inputs**.

## Why
The standard `extension-release-published.yml` in `liquibase/build-logic` derives the Maven version by stripping a leading `v` from the GitHub tag:

```bash
VERSION="${VERSION#v}"     # "v5.0.3-hibernate6" -> "5.0.3-hibernate6"
for jar_file in *-"${VERSION}".jar; do ...
```

That works fine when tag = `v<version>`, but for parallel-branch releases (e.g. hibernate6) the tag carries a suffix like `v5.0.3-hibernate6` while the artifacts are named `liquibase-hibernate6-5.0.3.jar`. The glob then matches nothing and nothing gets published to Maven Central — silently.

This workflow keeps `tag/releaseId` (for downloading from the right GitHub release) and `version` (for matching jars and Maven metadata) decoupled, unblocking H6 5.0.3 today and any future H6 release.

## Inputs
- `releaseId` (optional): GitHub release ID. **Use this for draft releases** — drafts have no git tag yet, so tag-based lookup returns 404.
- `tag` (optional): GitHub release tag (e.g. `v5.0.3-hibernate6`). Use for already-published releases. Ignored if `releaseId` is set.
- `version` (required): Maven Central artifact version (e.g. `5.0.3`).
- `javaBuildVersion` (default `21`), `artifactPath` (default `.`).

One of `releaseId` or `tag` must be provided.

## Usage for H6 5.0.3 (draft, today)
Actions → "Publish to Sonatype (manual)" → Run workflow on `hibernate6`:
- `releaseId`: `324362438` (the current draft)
- `version`: `5.0.3`

Reuses the existing AWS vault / Sonatype credentials / GPG signing infrastructure via `liquibase/build-logic/.github/actions/publish-to-central-portal`.

## Test plan
- [ ] Merge this PR
- [ ] Run the workflow with releaseId=`324362438`, version=`5.0.3`
- [ ] Confirm `liquibase-hibernate6:5.0.3` appears in the Sonatype Central Portal staging deployment
- [ ] Promote the deployment and confirm it shows on Maven Central after sync
- [ ] After Central Portal confirms, optionally publish the GitHub draft for visibility (auto-fired `release-published.yml` will fail to find files; harmless)

## Follow-ups
The right long-term fix is to add a `version` input to build-logic's `extension-release-published.yml` so the standard release-published flow works for branched releases. That's a build-logic PR for another day.