### PR TITLE
fix: support draft releases in publish-to-sonatype workflow

### DIFF
--- a/.github/workflows/publish-to-sonatype.yml
+++ b/.github/workflows/publish-to-sonatype.yml
@@ -11,9 +11,13 @@ name: Publish to Sonatype (manual)
 on:
   workflow_dispatch:
     inputs:
+      releaseId:
+        description: "GitHub release ID to download artifacts from. Use this for draft releases (where no git tag exists yet). Find via API or the draft URL."
+        required: false
+        type: string
       tag:
-        description: "GitHub release tag to download artifacts from (e.g. v5.0.3-hibernate6)"
-        required: true
+        description: "GitHub release tag (e.g. v5.0.3-hibernate6). Use this for already-published releases. Ignored if releaseId is set."
+        required: false
         type: string
       version:
         description: "Maven Central artifact version (e.g. 5.0.3) — used for file matching and deployment metadata"
@@ -75,7 +79,23 @@ jobs:
           path: build-logic
           sparse-checkout: .github/actions/publish-to-central-portal
 
-      - name: Download Release Artifacts
+      - name: Validate release inputs
+        run: |
+          if [ -z "${{ inputs.releaseId }}" ] && [ -z "${{ inputs.tag }}" ]; then
+            echo "::error::One of 'releaseId' or 'tag' must be provided."
+            exit 1
+          fi
+
+      - name: Download Release Artifacts (by release ID)
+        if: ${{ inputs.releaseId != '' }}
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        with:
+          releaseId: ${{ inputs.releaseId }}
+          fileName: "*"
+          out-file-path: ${{ inputs.artifactPath }}
+
+      - name: Download Release Artifacts (by tag)
+        if: ${{ inputs.releaseId == '' && inputs.tag != '' }}
         uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           tag: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary
Adds an optional `releaseId` input to the `publish-to-sonatype.yml` workflow so it can handle draft releases.

## Why
The workflow merged in #888 only accepts a `tag` input. `robinraju/release-downloader` resolves tags via `/releases/tags/{tag}`, which returns **404 for drafts** — the git tag is not created until the release is published. That blocks our intended flow for H6 5.0.3:

1. Publish to Maven Central via this workflow (while the GitHub release is still a draft)
2. **Then** click Publish on the GitHub draft, knowing the broken auto-trigger of `release-published.yml` will fail harmlessly (Maven Central is already populated)

Without draft support, we'd have to publish the GitHub draft first → broken auto-trigger fires concurrently → race condition with our manual workflow → unnecessary noise.

## Changes
- `releaseId` (new, optional): GitHub release ID — works for drafts and published releases.
- `tag` (now optional): kept as a fallback for already-published releases.
- Validation step: errors out if neither is provided.
- Download step split into two `if:`-gated variants.

## Usage for H6 5.0.3 (today)
Actions → "Publish to Sonatype (manual)" → Run workflow on `hibernate6`:
- `releaseId`: `324362438` (the current draft)
- `version`: `5.0.3`
- Leave `tag` empty.

## Test plan
- [ ] Merge this PR
- [ ] Run the workflow with releaseId=`324362438`, version=`5.0.3`
- [ ] Confirm `liquibase-hibernate6:5.0.3` appears in Sonatype Central Portal staging
- [ ] Promote → verify on Maven Central after sync