### PR TITLE
feat: add publish-to-sonatype workflow on main

### DIFF
--- a/.github/workflows/publish-to-sonatype.yml
+++ b/.github/workflows/publish-to-sonatype.yml
@@ -1,0 +1,111 @@
+name: Publish to Sonatype (manual)
+
+# Manual publish workflow for parallel-branch releases (e.g. hibernate6)
+# where the GitHub tag has a suffix that the standard
+# extension-release-published.yml can't strip cleanly.
+#
+# Downloads artifacts attached to a draft/published release by tag,
+# then calls build-logic's publish-to-central-portal action with the
+# clean Maven version supplied as a separate input.
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseId:
+        description: "GitHub release ID to download artifacts from. Use this for draft releases (where no git tag exists yet). Find via API or the draft URL."
+        required: false
+        type: string
+      tag:
+        description: "GitHub release tag (e.g. v5.0.3-hibernate6). Use this for already-published releases. Ignored if releaseId is set."
+        required: false
+        type: string
+      version:
+        description: "Maven Central artifact version (e.g. 5.0.3) — used for file matching and deployment metadata"
+        required: true
+        type: string
+      javaBuildVersion:
+        description: "Java version for the publish step"
+        required: false
+        default: "21"
+        type: string
+      artifactPath:
+        description: "Directory to download release artifacts into"
+        required: false
+        default: "."
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.javaBuildVersion }}
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        with:
+          gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+
+      - name: Checkout build-logic for publish action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: liquibase/build-logic
+          ref: main
+          path: build-logic
+          sparse-checkout: .github/actions/publish-to-central-portal
+
+      - name: Validate release inputs
+        run: |
+          if [ -z "${{ inputs.releaseId }}" ] && [ -z "${{ inputs.tag }}" ]; then
+            echo "::error::One of 'releaseId' or 'tag' must be provided."
+            exit 1
+          fi
+
+      - name: Download Release Artifacts (by release ID)
+        if: ${{ inputs.releaseId != '' }}
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        with:
+          releaseId: ${{ inputs.releaseId }}
+          fileName: "*"
+          out-file-path: ${{ inputs.artifactPath }}
+
+      - name: Download Release Artifacts (by tag)
+        if: ${{ inputs.releaseId == '' && inputs.tag != '' }}
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        with:
+          tag: ${{ inputs.tag }}
+          fileName: "*"
+          out-file-path: ${{ inputs.artifactPath }}
+
+      - name: Publish to Central Portal
+        uses: ./build-logic/.github/actions/publish-to-central-portal
+        with:
+          artifacts-dir: ${{ inputs.artifactPath }}
+          version: ${{ inputs.version }}
+          sonatype-username: ${{ env.SONATYPE_USERNAME }}
+          sonatype-token: ${{ env.SONATYPE_TOKEN }}


### PR DESCRIPTION
## Summary
Adds the `publish-to-sonatype.yml` workflow (already on `hibernate6`) to `main` so it can be dispatched via UI or `gh workflow run`.

## Why
GitHub binds `workflow_dispatch` to the **default branch**: a workflow only becomes dispatchable (UI dropdown or `gh workflow run --ref <any-branch>`) once its file exists on `main`, even if the dispatch is targeting a different ref. Without this, the workflow lives only on `hibernate6` and is uncallable — confirmed via:

```
$ gh workflow run publish-to-sonatype.yml --ref hibernate6 ...
HTTP 404: workflow publish-to-sonatype.yml not found on the default branch
```

## What this changes
- Identical copy of the workflow file. Branch-agnostic by design — takes `releaseId`/`tag` and `version` as inputs, downloads release artifacts, calls `liquibase/build-logic/.github/actions/publish-to-central-portal` with the clean version.
- Future H6 releases can dispatch against `--ref hibernate6`; future H7 releases dispatch against `--ref main`. Same file, both work.

## Test plan
- [ ] Merge this PR
- [ ] Dispatch with `gh workflow run publish-to-sonatype.yml --ref hibernate6 -f releaseId=324362438 -f version=5.0.3`
- [ ] Confirm `liquibase-hibernate6:5.0.3` lands in Sonatype Central Portal staging