### PR TITLE
fix: add actions:read to dry run release job

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -72,6 +72,7 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
     secrets: inherit
     permissions:
+      actions: read
       id-token: write
       contents: write
       packages: write


### PR DESCRIPTION
Dry run release has been failing with startup_failure every week since June 10th. Cause: extension-release-published requires actions:read since liquibase/build-logic#622 and the explicit permissions block on the dry-run-release-published job was rejecting the call before any job could run, that is also why the slack notify never fired.
Validated on liquibase-db2i: https://github.com/liquibase/liquibase-db2i/actions/runs/32308143519
