### PR TITLE
release: prepare for v5.0.4 + update hibernate 6.x and spring 6.x

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -76,6 +76,7 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      actions: read
     with:
       dry_run: true
       dry_run_version: "0.0.${{ github.run_number }}"

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent-pom</artifactId>
-        <version>1.0.0</version> <!-- Replace with the desired version -->
+        <version>1.0.2</version> <!-- Replace with the desired version -->
     </parent>
 
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-hibernate6</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.0.4-SNAPSHOT</version>
 
     <name>Liquibase Hibernate Integration</name>
     <description>Liquibase extension for hibernate integration including generating changesets based on changed
@@ -71,9 +71,9 @@
     </ciManagement>
 
     <properties>
-        <hibernate.version>6.6.15.Final</hibernate.version>
-        <spring.version>6.2.10</spring.version>
-        <liquibase.version>5.0.2</liquibase.version>
+        <hibernate.version>6.6.55.Final</hibernate.version>
+        <spring.version>6.2.19</spring.version>
+        <liquibase.version>5.0.4</liquibase.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>


### PR DESCRIPTION
Prepares the hibernate6 line for v5.0.4 and catches the branch up on its own dependency line. Base is hibernate6, not main.

liquibase.version goes 5.0.2 to 5.0.4. Worth flagging: #887 moved the project version to 5.0.3-SNAPSHOT for the last release but left liquibase.version at 5.0.2, so the published v5.0.3-hibernate6 artifact was built against core 5.0.2 rather than 5.0.3.

Parent pom goes 1.0.0 to 1.0.2. 1.0.0 has no annotationProcessorPaths, so lombok never runs and the test sources fail to compile with "cannot find symbol: getUserName()" on current Maven. Confirmed on the untouched branch, so this is pre-existing and not caused by the bumps here. 1.0.2 is what main already uses.

hibernate.version goes 6.6.15.Final to 6.6.55.Final and spring.version 6.2.10 to 6.2.19, both staying on the 6.x line. The branch had no dependabot coverage (dependabot.yml has no target-branch entry for it), so it had not moved since May. spring 6.2.10 is also affected by GHSA-jmp9-x22r-554x, though the spring dependencies here are provided scope and are not shipped in the jar.

Also adds the actions:read permission the dry-run-release job needs since liquibase/build-logic#622. That fix landed on main in #923 and this branch never got it.

Local run against these versions: 23 tests, no failures.

Nothing else from main applies. It carries the Hibernate 7 migration, which deliberately dropped 6.x support, and the one functional fix there (#877) is titled "Hibernate 7.1/7.2 compatibility for getMemberDetails()".
