### PR TITLE
fix: add actions:read to the release-published workflow

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -34,6 +34,7 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
+  actions: read
 
 jobs:
   release:


### PR DESCRIPTION
Dispatching release-published on this branch dies with startup_failure and zero jobs: the workflow level permissions block does not grant actions:read, which extension-release-published has required since liquibase/build-logic#622.

Blocks the Sonatype publish for v5.0.4-hibernate6, which is already published on GitHub with its 16 assets. #924 fixed the same gap on dry-run-release.yml and missed this file.