### PR TITLE
fix: pin setup-maven-settings to a commit SHA

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -77,7 +77,7 @@ jobs:
           cache: "maven"
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@0d56860f162d1d32c976d179e1dbd1663e18733b # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 


### PR DESCRIPTION
Dispatching release-published on this branch dies with startup_failure and zero jobs, which blocks the Sonatype publish for v5.0.4-hibernate6 (already published on GitHub with its 16 assets).

setup-maven-settings is the only step level uses ref in the file still on @main. Every other step here already carries a full SHA. Step level refs are subject to the SHA pinning policy while job level reusable workflow refs like *.yml@main are exempt, which is why the reusable call is fine and this one is not. The branch predates that pinning work (TECHOPS-81 and TECHOPS-646 ran against the default branches), so it never got swept.

Pinned to build-logic main as of today. This also explains why the same dispatch worked in May and fails now, with no change to the file in between.