### PR TITLE
ci: create the release draft on push to hibernate6

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,6 +2,9 @@ name: Create Release
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - hibernate6
 
 permissions:
   contents: write


### PR DESCRIPTION
The main branch creates its draft on every push, this branch only on manual dispatch. Since extension-attach-artifact-release requires a pre-existing draft, the build fired by a merge here dies with 'No draft release found in the repository', which is what happened on the v5.0.4-hibernate6 release.

With this the sequence works the same way it does on main: merge, draft appears, artifacts get attached.