### PR TITLE
ci: let dependabot watch the hibernate6 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,20 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+
+# The hibernate6 branch keeps the 6.x line alive and is not the default branch,
+# so it needs its own entries or dependabot never looks at it.
+- package-ecosystem: maven
+  directory: "/"
+  target-branch: "hibernate6"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  labels:
+      - "sdou"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  target-branch: "hibernate6"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Dependabot reads .github/dependabot.yml only from the default branch, so hibernate6 was never scanned. It stayed on hibernate 6.6.15.Final and spring 6.2.10 from May until the v5.0.4 release prep in #924 moved them to 6.6.55.Final and 6.2.19 by hand. spring 6.2.10 is affected by GHSA-jmp9-x22r-554x, though those dependencies are provided scope and not shipped in the jar.

Weekly rather than daily on that branch: it is a maintenance line, and the goal is to keep it from freezing again, not to generate noise.

Both entries stay on the 6.x line by construction, since dependabot bumps within what the branch pom already declares.